### PR TITLE
Re-fix CLI loading instruction

### DIFF
--- a/postgis-intro/sources/en/loading_data.rst
+++ b/postgis-intro/sources/en/loading_data.rst
@@ -61,16 +61,16 @@ Supported by a wide variety of libraries and applications, PostGIS provides many
    * ``nyc_subway_stations.shp``
    * ``nyc_homicides.shp``
    
-#. Or, to load data via CLI tools, use:
+#. Alternatively, you can load the data via CLI. Navigate to the workshop data bundle directory and run the following commands in bash.
 
-.. code-block ::
+   .. code-block :: bash
 
-   DATAFILES='nyc_census_blocks nyc_streets nyc_neighborhoods nyc_subway_stations nyc_homicides'
-   for datafile in $DATAFILES
-   do
-       shp2pgsql -s 26918 _local/data/data_bundle/data/${datafile}.shp > ${datafile}.sql
-       PGPASSWORD=${PROJECTNAME} psql -h localhost -U postgres -d nyc -f ${datafile}.sql
-   done
+      DATAFILES='nyc_census_blocks nyc_streets nyc_neighborhoods nyc_subway_stations nyc_homicides' for datafile in $DATAFILES do
+          shp2pgsql -s 26918 -I data/${datafile}.shp > ${datafile}.sql
+          PGPASSWORD=postgres psql -h localhost -U postgres -d nyc -f ${datafile}.sql
+      done
+   
+   Note that ``-I`` option tells ``shp2pgsql`` to create spatial index on geometry column.
  
 #. When all the files are loaded, click the "Refresh" button in pgAdmin to update the tree view. You should see your four tables show up in the **Databases > nyc > Schemas > public > Tables** section of the tree.
 


### PR DESCRIPTION
Previously, I "fixed" the styling straight in gh editor, on the fly - without checking html output.
As it turned out I completelly messed up the page - bash snippet was not being rendered at all.
This commit fixes that mistake:
![2020-10-06-130418_840x233_scrot](https://user-images.githubusercontent.com/18517327/95183377-f3d2b400-07d6-11eb-8012-34ca05521d55.png)


PS pardon for spamming with PRs!