### PR TITLE
Clarification about this page

### DIFF
--- a/postgis-intro/sources/en/loading_data.rst
+++ b/postgis-intro/sources/en/loading_data.rst
@@ -44,7 +44,7 @@ Loading with ogr2ogr
 
 **Windows**:
   * Builds of ogr2ogr can be downloaded from `GIS Internals <https://www.gisinternals.com/release.php>`_.
-  * ogr2ogr is included as part of `QGIS Install <https://qgis.org/en/site/forusers/download.html>`_ and accessible via QGIS4W Shell menu -
+  * ogr2ogr is included as part of `QGIS Install <https://qgis.org/en/site/forusers/download.html>`_ and accessible via OSGeo4W Shell -
   * Builds of ogr2ogr can be downloaded from `MS4W <https://ms4w.com/download.html>`_.
 
 **MacOS**:
@@ -56,10 +56,18 @@ Loading with ogr2ogr
   * If you installed Linux from packages, :file:`ogr2ogr` should be installed and on your PATH already as part of the **gdal** or *libgdal** packages.
 
 The postgis workshop data directory includes a :file:`2000/` sub-directory, which contains shape files from the 2000 census, that were obsoleted by data from the 2010 census. We can practice data loading using those files, to avoid creating name collisions with the data we already loaded using the backup file.
+Be sure to be in the :file:`2000/` sub-directory with the shell when doing these instructions:
 
 ::
 
   export PGPASSWORD=mydatabasepassword
+
+Rather than passing the password in the connection string, we put it in the environment, so it won't be visible in the process list while the command runs.
+
+Note that on Windows, you will need to use ``set`` instead of ``export``.
+
+::
+
 
   ogr2ogr \
     -nln nyc_census_blocks_2000 \
@@ -70,13 +78,10 @@ The postgis workshop data directory includes a :file:`2000/` sub-directory, whic
     Pg:'dbname=nyc host=localhost user=pramsey port=5432' \
     nyc_census_blocks_2000.shp
 
+
+For more visual clarity, these lines are displayed with ``\``, but they should be written in one line on your shell.
+
 The :file:`ogr2ogr` has a **huge** number of options, and we're only using a handful of them here. Here is a line-by-line explanation of the command.
-
-::
-
-  export PGPASSWORD=mydatabasepassword
-
-Rather than passing the password in the connection string, we put it in the environment, so it won't be visible in the process list while the command runs.
 
 ::
 


### PR DESCRIPTION
All of my modification are for the part "5.2. Loading with ogr2ogr"

As a beginner in every programming languages, some things were for me unclear, so I have decided to propose changes so that it can become more clear for beginners.

I added :
- line 59 (Be sure to be in the :file:`2000/` sub-directory with the shell when doing these instructions:),
- line 67  (Note that on Windows, you will need to use ``set`` instead of ``export``.)
- line 82 (For more visual clarity, these lines are displayed with ``\``, but they should be written in one line on your shell.)

I did some modification on line 47 ( accessible via QGIS4W Shell menu --> accessible via OSGeo4W Shell).

I separate the two parts of export ..... and ogr2ogr because (always as a beginner), I thought that that was one script that should be written in the pgAdmin Query tool (as it was not clearly said that I should open ogr2ogr after installing).

I moved the explanation of the export PGPASSWORD before the running of ogr2ogr -nln ....... so that it can fit with the separation I explained before.