### PR TITLE
Update spatial_relationships_exercises.rst

### DIFF
--- a/postgis-intro/sources/en/spatial_relationships_exercises.rst
+++ b/postgis-intro/sources/en/spatial_relationships_exercises.rst
@@ -83,7 +83,7 @@ Exercises
     FROM nyc_streets 
     WHERE ST_DWithin(
       geom, 
-      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
+      ST_GeomFromText('MULTILINESTRING((586781.701577724 4504202.15314339,586863.51964484 4504215.9881701))', 26918),
       0.1
     );
     
@@ -91,6 +91,7 @@ Exercises
   
            name
       ------------------
+       S Oxford St
        Cumberland St
        Atlantic Commons
 


### PR DESCRIPTION
I've updated the answer key to use Multilinestring instead of Linestring in the query identifying which streets Atlantic Commons joins with, and updated the answer key to include S. Oxford Street.

The existing answer key says moving from Multilinestring to Linestring saves keystrokes and that both methods describe the same shape but this isn't true, which is evident because the Linestring representation of Atlantic Commons doesn't join with South Oxford Street. Although the note above says we can no longer use ST_Touches(), ST_DWithin also provides incorrect results with the 0.1m buffer.

I think keeping the Multilinestring Representation is preferable, at least for this question.