### PR TITLE
[Potential bug?] Update spatial_relationships_exercises.rst

### DIFF
--- a/postgis-intro/sources/en/spatial_relationships_exercises.rst
+++ b/postgis-intro/sources/en/spatial_relationships_exercises.rst
@@ -83,7 +83,7 @@ Exercises
     FROM nyc_streets 
     WHERE ST_DWithin(
       geom, 
-      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
+      (SELECT geom FROM nyc_streets WHERE name = 'Atlantic Commons'),
       0.1
     );
     
@@ -91,6 +91,7 @@ Exercises
   
            name
       ------------------
+       S Oxford St
        Cumberland St
        Atlantic Commons
 

--- a/postgis-intro/sources/en/spatial_relationships_exercises.rst
+++ b/postgis-intro/sources/en/spatial_relationships_exercises.rst
@@ -55,12 +55,11 @@ Exercises
      
   .. code-block:: sql
 
-    SELECT name, boroname 
-    FROM nyc_neighborhoods 
-    WHERE ST_Intersects(
-      geom,
-      ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918)
-    );
+    SELECT n.name, n.boroname
+    FROM nyc_neighborhoods AS n
+    JOIN nyc_streets AS s
+      ON ST_Intersects(n.geom, s.geom)
+    WHERE s.name = 'Atlantic Commons';
 
   ::
      
@@ -79,13 +78,12 @@ Exercises
  
   .. code-block:: sql
 
-    SELECT name 
-    FROM nyc_streets 
-    WHERE ST_DWithin(
-      geom, 
-      (SELECT geom FROM nyc_streets WHERE name = 'Atlantic Commons'),
-      0.1
-    );
+    SELECT s.name
+    FROM nyc_streets AS s
+    JOIN nyc_streets AS ac
+      ON ST_DWithin(s.geom, ac.geom, 0.1)
+    WHERE ac.name = 'Atlantic Commons'
+      AND s.gid <> ac.gid;
     
   ::
   
@@ -93,7 +91,6 @@ Exercises
       ------------------
        S Oxford St
        Cumberland St
-       Atlantic Commons
 
   .. image:: ./spatial_relationships/atlantic_commons.jpg
   

--- a/postgis-intro/sources/en/static/workshop-sql.txt
+++ b/postgis-intro/sources/en/static/workshop-sql.txt
@@ -277,21 +277,19 @@ SELECT ST_AsText(geom)
   WHERE name = 'Atlantic Commons';
 
 -- What neighborhood and borough is Atlantic Commons in?
-SELECT name, boroname
-FROM nyc_neighborhoods
-WHERE ST_Intersects(
-  geom,
-  ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918)
-);
+SELECT n.name, n.boroname
+FROM nyc_neighborhoods AS n
+JOIN nyc_streets AS s
+  ON ST_Intersects(n.geom, s.geom)
+WHERE s.name = 'Atlantic Commons';
 
 -- What streets does Atlantic Commons join with?
-SELECT name
-FROM nyc_streets
-WHERE ST_DWithin(
-  geom,
-  ST_GeomFromText('LINESTRING(586782 4504202,586864 4504216)', 26918),
-  0.1
-);
+SELECT s.name
+FROM nyc_streets AS s
+JOIN nyc_streets AS ac
+  ON ST_DWithin(s.geom, ac.geom, 0.1)
+WHERE ac.name = 'Atlantic Commons'
+  AND s.gid <> ac.gid;
 
 -- Approximately how many people live on (within 50 meters of) Atlantic Commons?
 SELECT Sum(popn_total)


### PR DESCRIPTION
Using a subquery instead of a string MULTILINESTRING or LINESTRING gives different and more accurate results.
The exercise asks for the following question : `What streets does Atlantic Commons join with?`

There seems to be a difference between raw geometry format and back/forth serialization! Maybe it is related to the SRID aspects ?

Using multilinestring or subquery : 
![image](https://github.com/user-attachments/assets/70b4e4ed-2e73-44e8-b4c7-1000f90924fd)

Using suggested parsed linestring :
![image](https://github.com/user-attachments/assets/add6471e-09a7-41d5-bf2e-ff22d21c4cee)

Also, for completion purpose, shouldn't the question be answered excluding the street itself (atlantic commons) ?