### PR TITLE
Fix sql block typo in geography.rst

### DIFF
--- a/postgis-intro/sources/en/geography.rst
+++ b/postgis-intro/sources/en/geography.rst
@@ -132,7 +132,7 @@ The difference is under the covers: the geography index will correctly handle qu
 
 Here's a query to find all the subway stations within 500 meters of the Empire State Building.
 
-.. code-block::sql
+.. code-block:: sql
 
   SWITH empire_state_building AS (
     SELECT 'POINT(-73.98501 40.74812)'::geography AS geog

--- a/postgis-intro/sources/en/geography.rst
+++ b/postgis-intro/sources/en/geography.rst
@@ -134,7 +134,7 @@ Here's a query to find all the subway stations within 500 meters of the Empire S
 
 .. code-block:: sql
 
-  SWITH empire_state_building AS (
+  WITH empire_state_building AS (
     SELECT 'POINT(-73.98501 40.74812)'::geography AS geog
   )
   SELECT name,


### PR DESCRIPTION
The query doesn't show up in the rendered HTML page because of a typo.
![image](https://github.com/user-attachments/assets/a413d0a7-7239-46d9-89ed-3890963f04ba)

