### PR TITLE
Use ST_PointOnSurface for tract proxy joins

### DIFF
--- a/postgis-intro/sources/en/joins_advanced.rst
+++ b/postgis-intro/sources/en/joins_advanced.rst
@@ -3,7 +3,7 @@
 More Spatial Joins
 ==================
 
-In the last section we saw the :command:`ST_Centroid(geometry)` and :command:`ST_Union([geometry])` functions, and some simple examples. In this section we will do some more elaborate things with them.
+In the last section we saw the :command:`ST_PointOnSurface(geometry)` and :command:`ST_Union([geometry])` functions, and some simple examples. In this section we will do some more elaborate things with them.
 
 .. _creatingtractstable:
 
@@ -134,7 +134,7 @@ In our interesting query (in :ref:`interestingquestion`) we used the :command:`S
 
 To avoid this kind of double counting there are two methods:
 
-* The simple method is to ensure that each tract only falls in **one** summary area (using :command:`ST_Centroid(geometry)`)
+* The simple method is to ensure that each tract only falls in **one** summary area (using :command:`ST_PointOnSurface(geometry)`)
 * The complex method is to divide crossing tracts at the borders (using :command:`ST_Intersection(geometry,geometry)`)
  
 Here is an example of using the simple method to avoid double counting in our graduate education query:
@@ -146,13 +146,13 @@ Here is an example of using the simple method to avoid double counting in our gr
     n.name, n.boroname 
   FROM nyc_neighborhoods n 
   JOIN nyc_census_tracts t 
-  ON ST_Contains(n.geom, ST_Centroid(t.geom)) 
+  ON ST_Contains(n.geom, ST_PointOnSurface(t.geom))
   WHERE t.edu_total > 0
   GROUP BY n.name, n.boroname
   ORDER BY graduate_pct DESC
   LIMIT 10;
   
-Note that the query takes longer to run now, because the :command:`ST_Centroid` function  has to be run on every census tract.
+Note that the query takes longer to run now, because the :command:`ST_PointOnSurface` function has to be run on every census tract.
 
 ::
 
@@ -233,6 +233,4 @@ The solution is to ensure that we have only distinct census blocks before passin
   5005743
 
 That's better! So a bit over half the population of New York is within 500m (about a 5-7 minute walk) of the subway.
-
-
 

--- a/postgis-intro/sources/jp/joins_advanced.rst
+++ b/postgis-intro/sources/jp/joins_advanced.rst
@@ -3,7 +3,7 @@
 第19章: 高度な空間結合
 ==============================
 
-１つ前の章において :command:`ST_Centroid(geometry)` 関数と :command:`ST_Union([geometry])` 関数、そして簡単な実用例を扱いました。このセクションでは、これらの関数を使い、より複雑な処理を行います。
+１つ前の章において :command:`ST_PointOnSurface(geometry)` 関数と :command:`ST_Union([geometry])` 関数、そして簡単な実用例を扱いました。このセクションでは、これらの関数を使い、より複雑な処理を行います。
 
 .. _creatingtractstable:
 
@@ -133,7 +133,7 @@
 
 重複して計数されるこの種の問題を避けるために、２つの対処方法があります。
 
- * 簡便な方法として、各国勢統計区が一つの集計区域に重なっていることを確認する方法（ :command:`ST_Centroid(geometry)` を使います）。
+ * 簡便な方法として、各国勢統計区が一つの集計区域に重なっていることを確認する方法（ :command:`ST_PointOnSurface(geometry)` を使います）。
  * 高度な方法として、境界線をまたぐ国勢統計区をその位置で分割する方法（ :command:`ST_Intersection(geometry,geometry)` を使います。
 
 以下に簡便な方法を使い、大学院教育に関するクエリで重複して計数されないようにする例を示します。
@@ -145,13 +145,13 @@
     n.name, n.boroname 
   FROM nyc_neighborhoods n 
   JOIN nyc_census_tracts t 
-  ON ST_Contains(n.the_geom, ST_Centroid(t.the_geom)) 
+  ON ST_Contains(n.the_geom, ST_PointOnSurface(t.the_geom))
   WHERE t.edu_total > 0
   GROUP BY n.name, n.boroname
   ORDER BY graduate_pct DESC
   LIMIT 10;
 
-このクエリは、 :command:`ST_Centroid` 関数が各国勢統計区に対して処理を実行するため、処理により多くの時間が必要になります。
+このクエリは、 :command:`ST_PointOnSurface` 関数が各国勢統計区に対して処理を実行するため、処理により多くの時間が必要になります。
 
 ::
 
@@ -225,8 +225,6 @@
   4953599
 
 よりよい答えが得られました。半数より少し多くの人が地下鉄から500メートル以内（徒歩5分から7分）にいることがわかりました。
-
-
 
 
 

--- a/postgis-intro/sources/locale/de/LC_MESSAGES/joins_advanced.po
+++ b/postgis-intro/sources/locale/de/LC_MESSAGES/joins_advanced.po
@@ -25,7 +25,7 @@ msgstr ""
 
 #: ../../en/joins_advanced.rst:6
 msgid ""
-"In the last section we saw the :command:`ST_Centroid(geometry)` and :command:"
+"In the last section we saw the :command:`ST_PointOnSurface(geometry)` and :command:"
 "`ST_Union([geometry])` functions, and some simple examples. In this section "
 "we will do some more elaborate things with them."
 msgstr ""
@@ -154,7 +154,7 @@ msgstr ""
 #: ../../en/joins_advanced.rst:137
 msgid ""
 "The simple method is to ensure that each tract only falls in **one** summary "
-"area (using :command:`ST_Centroid(geometry)`)"
+"area (using :command:`ST_PointOnSurface(geometry)`)"
 msgstr ""
 
 #: ../../en/joins_advanced.rst:138
@@ -172,7 +172,7 @@ msgstr ""
 #: ../../en/joins_advanced.rst:155
 msgid ""
 "Note that the query takes longer to run now, because the :command:"
-"`ST_Centroid` function  has to be run on every census tract."
+"`ST_PointOnSurface` function has to be run on every census tract."
 msgstr ""
 
 #: ../../en/joins_advanced.rst:172

--- a/postgis-intro/sources/locale/es/LC_MESSAGES/joins_advanced.po
+++ b/postgis-intro/sources/locale/es/LC_MESSAGES/joins_advanced.po
@@ -28,11 +28,11 @@ msgstr "Más Joins Espaciales"
 
 #: ../../en/joins_advanced.rst:6
 msgid ""
-"In the last section we saw the :command:`ST_Centroid(geometry)` and :command:"
+"In the last section we saw the :command:`ST_PointOnSurface(geometry)` and :command:"
 "`ST_Union([geometry])` functions, and some simple examples. In this section "
 "we will do some more elaborate things with them."
 msgstr ""
-"En la última sección vimos las funciones :command:`ST_Centroid(geometría)` y "
+"En la última sección vimos las funciones :command:`ST_PointOnSurface(geometría)` y "
 ":command:`ST_Union([geometría])`, y algunos ejemplos sencillos. En esta "
 "sección haremos algunas cosas más elaboradas con ellas."
 
@@ -191,10 +191,10 @@ msgstr "Para evitar este tipo de doble conteo hay dos métodos:"
 #: ../../en/joins_advanced.rst:137
 msgid ""
 "The simple method is to ensure that each tract only falls in **one** summary "
-"area (using :command:`ST_Centroid(geometry)`)"
+"area (using :command:`ST_PointOnSurface(geometry)`)"
 msgstr ""
 "El método simple es asegurar que cada distrito solo caiga en **una** área de "
-"resumen (usando :command:`ST_Centroid(geometry)`)"
+"resumen (usando :command:`ST_PointOnSurface(geometry)`)"
 
 #: ../../en/joins_advanced.rst:138
 msgid ""
@@ -215,10 +215,10 @@ msgstr ""
 #: ../../en/joins_advanced.rst:155
 msgid ""
 "Note that the query takes longer to run now, because the :command:"
-"`ST_Centroid` function  has to be run on every census tract."
+"`ST_PointOnSurface` function has to be run on every census tract."
 msgstr ""
 "Observa que la consulta tarda más en ejecutarse ahora, porque la función "
-":command:`ST_Centroid` debe ejecutarse en cada distrito censal."
+":command:`ST_PointOnSurface` debe ejecutarse en cada distrito censal."
 
 #: ../../en/joins_advanced.rst:172
 msgid "Avoiding double counting changes the results!"

--- a/postgis-intro/sources/locale/ja/LC_MESSAGES/joins_advanced.po
+++ b/postgis-intro/sources/locale/ja/LC_MESSAGES/joins_advanced.po
@@ -27,11 +27,11 @@ msgstr "その他の空間結合"
 
 #: ../../en/joins_advanced.rst:6
 msgid ""
-"In the last section we saw the :command:`ST_Centroid(geometry)` and :command:"
+"In the last section we saw the :command:`ST_PointOnSurface(geometry)` and :command:"
 "`ST_Union([geometry])` functions, and some simple examples. In this section "
 "we will do some more elaborate things with them."
 msgstr ""
-"前のセクションで、:command:`ST_Centroid(geometry)` 関数と "
+"前のセクションで、:command:`ST_PointOnSurface(geometry)` 関数と "
 ":command:`ST_Union([geometry])` "
 "関数と、簡単な例を見ました。このセクションでは、より複雑なことを行います。"
 
@@ -181,10 +181,10 @@ msgstr "この種の二重カウントを避けるには二つの方法があり
 #: ../../en/joins_advanced.rst:137
 msgid ""
 "The simple method is to ensure that each tract only falls in **one** summary "
-"area (using :command:`ST_Centroid(geometry)`)"
+"area (using :command:`ST_PointOnSurface(geometry)`)"
 msgstr ""
 "単純な方法として、それぞれの統計区を**一つの**"
-"集約領域だけに収まるようにします (:command:`ST_Centroid(geometry)` "
+"集約領域だけに収まるようにします (:command:`ST_PointOnSurface(geometry)` "
 "を使います)"
 
 #: ../../en/joins_advanced.rst:138
@@ -204,9 +204,9 @@ msgstr "大学院教育のクエリで二重カウントを回避する単純な
 #: ../../en/joins_advanced.rst:155
 msgid ""
 "Note that the query takes longer to run now, because the :command:"
-"`ST_Centroid` function  has to be run on every census tract."
+"`ST_PointOnSurface` function has to be run on every census tract."
 msgstr ""
-"このクエリは時間がかかります。というのも、:command:`ST_Centroid` "
+"このクエリは時間がかかります。というのも、:command:`ST_PointOnSurface` "
 "関数を全ての統計区について実行しなければならないからです。"
 
 #: ../../en/joins_advanced.rst:172

--- a/postgis-intro/sources/locale/pot/joins_advanced.pot
+++ b/postgis-intro/sources/locale/pot/joins_advanced.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Introduction to PostGIS 1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-07 21:46-0500\n"
+"POT-Creation-Date: 2026-07-28 11:17+0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgid "More Spatial Joins"
 msgstr ""
 
 #: ../../en/joins_advanced.rst:6
-msgid "In the last section we saw the :command:`ST_Centroid(geometry)` and :command:`ST_Union([geometry])` functions, and some simple examples. In this section we will do some more elaborate things with them."
+msgid "In the last section we saw the :command:`ST_PointOnSurface(geometry)` and :command:`ST_Union([geometry])` functions, and some simple examples. In this section we will do some more elaborate things with them."
 msgstr ""
 
 #: ../../en/joins_advanced.rst:11
@@ -118,7 +118,7 @@ msgid "To avoid this kind of double counting there are two methods:"
 msgstr ""
 
 #: ../../en/joins_advanced.rst:137
-msgid "The simple method is to ensure that each tract only falls in **one** summary area (using :command:`ST_Centroid(geometry)`)"
+msgid "The simple method is to ensure that each tract only falls in **one** summary area (using :command:`ST_PointOnSurface(geometry)`)"
 msgstr ""
 
 #: ../../en/joins_advanced.rst:138
@@ -130,7 +130,7 @@ msgid "Here is an example of using the simple method to avoid double counting in
 msgstr ""
 
 #: ../../en/joins_advanced.rst:155
-msgid "Note that the query takes longer to run now, because the :command:`ST_Centroid` function  has to be run on every census tract."
+msgid "Note that the query takes longer to run now, because the :command:`ST_PointOnSurface` function has to be run on every census tract."
 msgstr ""
 
 #: ../../en/joins_advanced.rst:172

--- a/postgis-intro/sources/locale/sv/LC_MESSAGES/joins_advanced.po
+++ b/postgis-intro/sources/locale/sv/LC_MESSAGES/joins_advanced.po
@@ -23,9 +23,9 @@ msgid "More Spatial Joins"
 msgstr "Fler spatiala sammanfogningar"
 
 #: ../../en/joins_advanced.rst:6
-msgid "In the last section we saw the :command:`ST_Centroid(geometry)` and :command:`ST_Union([geometry])` functions, and some simple examples. In this section we will do some more elaborate things with them."
+msgid "In the last section we saw the :command:`ST_PointOnSurface(geometry)` and :command:`ST_Union([geometry])` functions, and some simple examples. In this section we will do some more elaborate things with them."
 msgstr ""
-"I förra avsnittet såg vi funktionerna :command:`ST_Centroid(geometry)` och "
+"I förra avsnittet såg vi funktionerna :command:`ST_PointOnSurface(geometry)` och "
 ":command:`ST_Union([geometry])`, och några enkla exempel. I det här "
 "avsnittet ska vi göra lite mer avancerade saker med dem."
 
@@ -151,10 +151,10 @@ msgid "To avoid this kind of double counting there are two methods:"
 msgstr "För att undvika denna typ av dubbelräkning finns det två metoder:"
 
 #: ../../en/joins_advanced.rst:137
-msgid "The simple method is to ensure that each tract only falls in **one** summary area (using :command:`ST_Centroid(geometry)`)"
+msgid "The simple method is to ensure that each tract only falls in **one** summary area (using :command:`ST_PointOnSurface(geometry)`)"
 msgstr ""
 "Den enkla metoden är att se till att varje trakt bara faller inom **ett** "
-"sammanfattningsområde (med hjälp av :command:`ST_Centroid(geometry)`)"
+"sammanfattningsområde (med hjälp av :command:`ST_PointOnSurface(geometry)`)"
 
 #: ../../en/joins_advanced.rst:138
 msgid "The complex method is to divide crossing tracts at the borders (using :command:`ST_Intersection(geometry,geometry)`)"
@@ -169,10 +169,10 @@ msgstr ""
 "dubbelräkning i vår fråga om forskarutbildning:"
 
 #: ../../en/joins_advanced.rst:155
-msgid "Note that the query takes longer to run now, because the :command:`ST_Centroid` function  has to be run on every census tract."
+msgid "Note that the query takes longer to run now, because the :command:`ST_PointOnSurface` function has to be run on every census tract."
 msgstr ""
 "Observera att det tar längre tid att köra frågan nu, eftersom funktionen "
-":command:`ST_Centroid` måste köras på varje folkräkningstrakt."
+":command:`ST_PointOnSurface` måste köras på varje folkräkningstrakt."
 
 #: ../../en/joins_advanced.rst:172
 msgid "Avoiding double counting changes the results!"


### PR DESCRIPTION
## Summary

- replace the tract proxy example in advanced joins with `ST_PointOnSurface`
- update the matching English, Japanese, POT, and existing translated catalog text
- keep the surrounding centroid discussion focused on averages, where `ST_Centroid` is still the intended function

## Validation

- `make -C postgis-intro/sources/en html`
- `make -C postgis-intro/sources/en pot`
- `LANG=ja make -C postgis-intro/sources/en html-translation`
- `LANG=es make -C postgis-intro/sources/en html-translation`
- `LANG=sv make -C postgis-intro/sources/en html-translation`
- `LANG=de make -C postgis-intro/sources/en html-translation`
- `make -C postgis-intro/sources/jp html`
- `git diff --check`
