### PR TITLE
Remove duplicate Simplified Chinese translator metadata

### DIFF
--- a/postgis-intro/sources/locale/zh_Hans/LC_MESSAGES/loading_data.po
+++ b/postgis-intro/sources/locale/zh_Hans/LC_MESSAGES/loading_data.po
@@ -2,7 +2,6 @@
 # Copyright (C) 2012-2023, Paul Ramsey | Mark Leslie | PostGIS contributors
 # This file is distributed under the same license as the Introduction to PostGIS package.
 # Zuochenwei <zuochenwei5@gmail.com>, 2024.
-# Wangdapeng <wangdapeng20191008@gmail.com>, 2025.
 # Dapeng Wang <wangdapeng20191008@gmail.com>, 2025.
 msgid ""
 msgstr ""


### PR DESCRIPTION
## Summary

- remove the duplicate Simplified Chinese translator metadata entry for Dapeng Wang
- leave the existing `Last-Translator` header and the non-duplicate author entry intact

Fixes postgis/postgis-workshops#144.

## Validation

- `msgfmt --check --check-header --output-file=/dev/null postgis-intro/sources/locale/zh_Hans/LC_MESSAGES/loading_data.po`
- `rg -n "Wangdapeng|Dapeng Wang" postgis-intro/sources/locale/zh_Hans/LC_MESSAGES/loading_data.po`
- `git diff --check`
