### PR TITLE
Remove broken case studies link

### DIFF
--- a/postgis-intro/sources/en/introduction.rst
+++ b/postgis-intro/sources/en/introduction.rst
@@ -153,8 +153,6 @@ Recent releases of PostGIS continue to add features and performance improvements
 Who uses PostGIS?
 -----------------
 
-For a complete list of case studies, see the `PostGIS case studies <https://postgis.net/category/casestudy/>`_ page.
-
 Institut Geographique National, France
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -209,4 +207,3 @@ The following table shows a list of some of the software that leverages PostGIS:
 |   * SAGA                                        |   * MapInfo                                  |
 |   * uDig                                        |   * Microimages TNTmips GIS                  |
 +-------------------------------------------------+----------------------------------------------+
-


### PR DESCRIPTION
## Summary

- remove the broken PostGIS case studies link from the introduction page
- keep the existing named examples that follow the removed link

Fixes postgis/postgis-workshops#153.

## Validation

- `make -C postgis-intro/sources/en html`
- `rg -n "category/casestudy" postgis-intro/doc/en/introduction.html postgis-intro/sources/en/introduction.rst` returns no matches
- `git diff --check`
