### PR TITLE
Add favicon through shared workshop theme

### DIFF
--- a/postgis-intro/sources/jp/conf.py
+++ b/postgis-intro/sources/jp/conf.py
@@ -103,7 +103,7 @@ html_title = project
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = 'favicon.ico'
+# html_favicon = 'favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/themes/postgis/layout.html
+++ b/themes/postgis/layout.html
@@ -34,6 +34,8 @@
 {%- endmacro %}
 
 {% block extrahead %}
+    {{ super() }}
+    <link rel="icon" href="{{ pathto('_static/favicon.ico', 1) }}" />
     {% if pagename == "index" %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- add the existing PostGIS favicon link in the shared workshop theme
- remove the legacy Japanese source's per-build favicon setting so the shared
  theme owns favicon output consistently
- verify English, translated Japanese, and legacy Japanese pages emit one
  favicon link

Fixes postgis/postgis-workshops#159.

## Validation

- `make -C postgis-intro/sources/en html`
- `LANG=ja make -C postgis-intro/sources/en html-translation`
- `make -C postgis-intro/sources/jp html`
- sampled English, translated Japanese, and legacy Japanese pages each emitted
  exactly one `_static/favicon.ico` link
- sampled English, translated Japanese, and legacy Japanese builds each copied
  `_static/favicon.ico`
- `git diff --check`
