### PR TITLE
Refresh topology topo type translation catalogs

### DIFF
--- a/postgis-intro/sources/locale/es/LC_MESSAGES/topology_topo_types.po
+++ b/postgis-intro/sources/locale/es/LC_MESSAGES/topology_topo_types.po
@@ -10,8 +10,7 @@ msgstr ""
 "POT-Creation-Date: 2025-06-10 18:57+0000\n"
 "PO-Revision-Date: 2025-09-04 23:47+0000\n"
 "Last-Translator: Paulo Cesar Coronado <paulocoronado@udistrital.edu.co>\n"
-"Language-Team: Spanish <https://weblate.osgeo.org/projects/postgis-workshop/"
-"topology_topo_types/es/>\n"
+"Language-Team: Spanish <https://weblate.osgeo.org/projects/postgis-workshop/topology_topo_types/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,485 +18,1038 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4.3\n"
 
-#: ../../en/topology_base_types.rst:4
-msgid "Topology Basic Types"
-msgstr "Tipos Básicos de Topología"
-
-#: ../../en/topology_base_types.rst:6
-msgid "Before read this document, at least check one of this documents:"
+#: ../../en/topology_topo_types.rst:4
+msgid "Topology and Geometry Representation"
 msgstr ""
-"Antes de leer este documento, consulte al menos uno de estos documentos:"
 
-#: ../../en/topology_base_types.rst:8
-msgid "`Introductory workshop: PostGIS Topology Workshop <topology.html>`_."
-msgstr "`Taller introductorio: Taller de Topología PostGIS <topology.html>`_."
-
-#: ../../en/topology_base_types.rst:10
-msgid "`Manual: PostGIS Topology <https://postgis.net/docs/Topology.html>`_."
+#: ../../en/topology_topo_types.rst:6
+msgid ""
+"Before reading this document, please review at least one of these resources:"
 msgstr ""
-"`Manual: Topología en PostGIS <https://postgis.net/docs/Topology.html>`_."
 
-#: ../../en/topology_base_types.rst:12
-msgid "`ISO Topology: OGC-SFS Geometries <https://www.gaia-gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+#: ../../en/topology_topo_types.rst:8
+msgid ""
+"`Topology Basic Types <https://postgis.net/workshops/en/postgis-"
+"intro/topology_base_types.html>`_"
 msgstr ""
-"`Topología en ISO: Geometrías OGC-SFS <https://www.gaia-gis.it/fossil/"
-"libspatialite/wiki?name=topo-intro>`_."
 
-#: ../../en/topology_base_types.rst:14
-msgid "In this workshop, we will check some fundamentals of topology, its basics and definitions. It is not intended to be a way to use them directly, is to understand it to then be able to use it easily."
+#: ../../en/topology_topo_types.rst:9
+msgid ""
+"`Introductory workshop: PostGIS Topology Workshop "
+"<https://postgis.net/workshops/en/postgis-intro/topology.html>`_"
 msgstr ""
-"En este taller revisaremos algunos fundamentos de topología, sus bases y "
-"definiciones. No pretende ser una forma de utilizarlos directamente, es "
-"entenderlo para luego poder utilizarlo fácilmente."
 
-#: ../../en/topology_base_types.rst:18
-msgid "Types"
-msgstr "Tipos"
-
-#: ../../en/topology_base_types.rst:23
-msgid "The basic topology works on three basic types."
-msgstr "La topología básica funciona con tres tipos básicos."
-
-#: ../../en/topology_base_types.rst:25
-msgid "Node: 2D point, everything starts or ends here"
-msgstr "Nodo: punto 2D, todo empieza o acaba aquí"
-
-#: ../../en/topology_base_types.rst:26
-msgid "Edge: A linestring with direction that start and ends on a node"
-msgstr "Arista: línea con dirección que comienza y termina en un nodo"
-
-#: ../../en/topology_base_types.rst:27
-msgid "Face: Closed set of linestrings, that conforms a polygon"
+#: ../../en/topology_topo_types.rst:11
+msgid ""
+"Having a Topology with all its Primitives is useful, but to make it more "
+"practical, we need a way to represent these elements in a table. Similar to "
+"how we have spatial tables, we can have topology tables."
 msgstr ""
-"Cara (Face): Conjunto cerrado de líneas (linestrings), que conforma un "
-"polígono"
 
-#: ../../en/topology_base_types.rst:29
-msgid "There are some rules for a set of nodes, edges and faces to be valid, check the ISO Topology document, has a very good summary of these conditions, a topology that follows all the rules, is a valid topology."
+#: ../../en/topology_topo_types.rst:14
+msgid "Introduction to geometry representation"
 msgstr ""
-"Existen algunas reglas para que un conjunto de nodos, aristas y caras sea "
-"válido. Revisa el documento ISO Topology, que tiene un muy buen resumen de "
-"estas condiciones. Una topología que sigue todas las reglas es una topología "
-"válida."
 
-#: ../../en/topology_base_types.rst:31
-msgid "Is good to know, until now Postgis will save all this information internally, each type has its own unique ID, and with it we can edit and change them using the available functions, for example with ST_RemEdgeNewFace you can remove an edge and create a new face."
+#: ../../en/topology_topo_types.rst:16
+msgid ""
+"If you have followed any example of using Topology to represent geometries "
+"you could remember this, when we populate a Topology table from a Geometry "
+"one we use TopoGeometries instead of Geometries, and in some way each "
+"TopoGeometry is able to represent one or several Primitives contained on the"
+" Topology."
 msgstr ""
-"Es bueno saber que, hasta ahora, PostGIS guardará toda esta información "
-"internamente, cada tipo tiene su propio ID único, y con él podemos editarlos "
-"y modificarlos usando las funciones disponibles. Por ejemplo, con "
-"ST_RemEdgeNewFace puedes eliminar una arista y crear una nueva cara."
 
-#: ../../en/topology_base_types.rst:33
-msgid "But there is still a missing piece, how do we say for example, a face has a specific attribute? Postgis implements several concepts to do this like Layers, TopoGeometry, TopoElement."
+#: ../../en/topology_topo_types.rst:21
+msgid ""
+"The point is how we reach the actual primitives from the TopoGeometry, how "
+"the data is structured, so first lets see the most global definitions:"
 msgstr ""
-"Pero aún falta una pieza: ¿cómo decimos, por ejemplo, que una cara tiene un "
-"atributo específico? PostGIS implementa varios conceptos para hacer esto "
-"como Layers, TopoGeometry, TopoElement."
 
-#: ../../en/topology_base_types.rst:36
-msgid "Universal Face"
-msgstr "Cara Universal"
-
-#: ../../en/topology_base_types.rst:38
-msgid "It Might be intuitive to think that only the faces constructed by edges exist, there is one exception, all the white space out of all the faces is also a face!"
+#: ../../en/topology_topo_types.rst:26
+msgid ""
+"A TopoGeometry can represent a group of Primitives or other TopoGeometries, "
+"in order to create a TopoGeometry you need a Layer."
 msgstr ""
-"Podría ser intuitivo pensar que solo existen las caras construidas por "
-"aristas, pero hay una excepción: ¡todo el espacio en blanco fuera de todas "
-"las caras también es una cara!"
 
-#: ../../en/topology_base_types.rst:40
-msgid "The empty space is called the Universal Face, when a Topology is empty, all the space is the Universal Face, when we add a linestring is an edge of this face, then when we make a polygon it is like make a hole in the face and stealing it to assign it to a face."
+#: ../../en/topology_topo_types.rst:28
+msgid ""
+"Layers are the biggest box, they store TopoGeometries which also stores "
+"TopoElements, this last ones represents Primitives or other TopoGeometries."
 msgstr ""
-"El espacio vacío se llama la Cara Universal. Cuando una topología está "
-"vacía, todo el espacio es la Cara Universal. Cuando añadimos una línea "
-"(linestring), esta es una arista de esa cara; luego, cuando creamos un "
-"polígono, es como hacer un agujero en la cara y “robarlo” para asignarlo a "
-"una cara."
 
-#: ../../en/topology_base_types.rst:42
-msgid "This face is infinite and does not have any boundary."
-msgstr "Esta cara es infinita y no tiene ningún límite."
-
-#: ../../en/topology_base_types.rst:49
-msgid "The Universal Face has the ID 0."
-msgstr "La Cara Universal tiene el ID 0."
-
-#: ../../en/topology_base_types.rst:52
-msgid "Edge interpretation"
-msgstr "Interpretación de Aristas"
-
-#: ../../en/topology_base_types.rst:54
-msgid "To correctly represent a topology and their forms, there are some definitions that are used to construct the tables that store everything, the edge is on the more complex ones."
+#: ../../en/topology_topo_types.rst:31
+msgid "Just to write in two ways:"
 msgstr ""
-"Para representar correctamente una topología y sus formas, hay algunas "
-"definiciones que se usan para construir las tablas que almacenan todo. La "
-"arista es una de las más complejas."
 
-#: ../../en/topology_base_types.rst:56
-msgid "All the information about edges is stored on the edge_data table, in your custom topology schema, and which information do we need in the edges? basically its nodes and faces information, edge is the primitive who connects both."
+#: ../../en/topology_topo_types.rst:33
+msgid "Layer contains"
 msgstr ""
-"Toda la información sobre las aristas se almacena en la tabla edge_data, en "
-"tu esquema de topología personalizada. ¿Y qué información necesitamos en las "
-"aristas? Básicamente la información de sus nodos y caras. La arista es la "
-"primitiva que conecta ambos."
 
-#: ../../en/topology_base_types.rst:58
-msgid "These linestrings are called Edges because they are the edges of the faces."
-msgstr "Estas líneas se llaman Aristas porque son los bordes de las caras."
-
-#: ../../en/topology_base_types.rst:61
-msgid "Edge direction, left and right"
-msgstr "Dirección de la arista, izquierda y derecha"
-
-#: ../../en/topology_base_types.rst:63
-msgid "Edges in topology has a right defined perspective and view, when we see them must be done in the next way:"
+#: ../../en/topology_topo_types.rst:35
+msgid ""
+"TopoGeometries where all of them has the same TopoElement's type, each one "
+"one contains:"
 msgstr ""
-"Las aristas en topología tienen una perspectiva y orientación definidas. "
-"Cuando las vemos, debe hacerse de la siguiente manera:"
 
-#: ../../en/topology_base_types.rst:68
-msgid "When we want to see from the edge perspective is always from the end node to the start edge, always looking the edge forward."
+#: ../../en/topology_topo_types.rst:37
+msgid "TopoElements where each one can represent a:"
 msgstr ""
-"Cuando queremos ver desde la perspectiva de la arista, siempre es desde el "
-"nodo final hacia el nodo inicial, siempre mirando hacia adelante en la "
-"arista."
 
-#: ../../en/topology_base_types.rst:74
-msgid "The edges have left and right properties, as we see they are defined using the edge perspective, see the linestring from the start node to the end node, there will always be a well defined left and right."
+#: ../../en/topology_topo_types.rst:39
+msgid "TopoGeometry of other Layer"
 msgstr ""
-"Las aristas tienen propiedades de izquierda y derecha. Como vemos, estas se "
-"definen usando la perspectiva de la arista: mirando la línea desde el nodo "
-"inicial hacia el nodo final, siempre habrá un lado izquierdo y un lado "
-"derecho bien definidos."
 
-#: ../../en/topology_base_types.rst:76
-msgid "So see the edge forward and you always have a left and right side."
+#: ../../en/topology_topo_types.rst:40
+msgid "Geometry Collection"
 msgstr ""
-"Así que mira la arista hacia adelante y siempre tendrás un lado izquierdo y "
-"uno derecho."
 
-#: ../../en/topology_base_types.rst:78
-msgid "This helps to relate which faces are on each side of the edge:"
-msgstr "Esto ayuda a relacionar qué caras están en cada lado de la arista:"
-
-#: ../../en/topology_base_types.rst:83
-msgid "Check the edges on the image, while almost all the edges go from down to up and left to right, there is an orange edge which has the opposite direction, so its sides left and right are swapped in reference to the others, but if you look the edge forward, the right and left are right."
+#: ../../en/topology_topo_types.rst:41
+msgid "Primitive from the Topology"
 msgstr ""
-"Observa las aristas en la imagen: aunque casi todas van de abajo hacia "
-"arriba y de izquierda a derecha, hay una arista naranja que tiene la "
-"dirección opuesta, por lo que sus lados izquierdo y derecho están invertidos "
-"con respecto a las demás. Pero si miras la arista hacia adelante, el lado "
-"derecho e izquierdo son correctos."
 
-#: ../../en/topology_base_types.rst:85
-msgid "Continue seeing the orange edge, while on its right has a polygon built by the edges, on the left is the Universal Face."
+#: ../../en/topology_topo_types.rst:43 ../../en/topology_topo_types.rst:62
+msgid "Nodes"
 msgstr ""
-"Siguiendo con la arista naranja, mientras que a su derecha tiene un polígono "
-"construido por las aristas, a la izquierda está la Cara Universal."
 
-#: ../../en/topology_base_types.rst:87
-msgid "When we want to analyze any edge, and we need to see it from the edge perspective, it is always looking the edge in forward, never in backward!"
+#: ../../en/topology_topo_types.rst:44 ../../en/topology_topo_types.rst:63
+msgid "Edges"
 msgstr ""
-"Cuando queremos analizar cualquier arista, y necesitamos verla desde la "
-"perspectiva de la arista, siempre es mirándola hacia adelante, ¡nunca hacia "
-"atrás!"
 
-#: ../../en/topology_base_types.rst:89
-msgid "Which are all the next edges? Looking forward we go from start node to the end node, all the edges who start or end in the end node of the edge!"
+#: ../../en/topology_topo_types.rst:45 ../../en/topology_topo_types.rst:64
+msgid "Faces"
 msgstr ""
-"¿Cuáles son las siguientes aristas? Mirando hacia adelante vamos del nodo "
-"inicial al nodo final, ¡todas las aristas que comienzan o terminan en el "
-"nodo final de la arista!"
 
-#: ../../en/topology_base_types.rst:92
-msgid "Edge Data"
-msgstr "Datos de la Arista"
-
-#: ../../en/topology_base_types.rst:94
-msgid "The edge_data table has information related to the edge, from what we know right now we can interpret the next columns:"
+#: ../../en/topology_topo_types.rst:47
+msgid ""
+"TopoGeometries are exposed as keys, they has a unique key inside the Layer, "
+"but also stores its Layer Key, this allows Postgis to store it in an "
+"arbitrary column and always be able to find its TopoElements, and with them "
+"what they represent."
 msgstr ""
-"La tabla edge_data tiene información relacionada con la arista. A partir de "
-"lo que sabemos hasta ahora, podemos interpretar las siguientes columnas:"
 
-#: ../../en/topology_base_types.rst:96
-msgid "edge_id: Unique ID for the edge"
-msgstr "edge_id: ID único para la arista"
-
-#: ../../en/topology_base_types.rst:97
-msgid "start_node: ID for the node who is the same as the start point of the edge"
+#: ../../en/topology_topo_types.rst:49
+msgid ""
+"You need a Layer where a TopoGeometry will be constructed, and after that "
+"you don't need to remember to which Layer it belongs."
 msgstr ""
-"start_node: ID del nodo que es el mismo que el punto inicial de la arista"
 
-#: ../../en/topology_base_types.rst:98
-msgid "end_node: ID for the node who is the same as the end point of the edge"
-msgstr "end_node: ID del nodo que es el mismo que el punto final de la arista"
-
-#: ../../en/topology_base_types.rst:99
-msgid "left_face: ID of the face on the left of the edge"
-msgstr "left_face: ID de la cara a la izquierda de la arista"
-
-#: ../../en/topology_base_types.rst:100
-msgid "right_face: ID of the face on the right of the edge"
-msgstr "right_face: ID de la cara a la derecha de la arista"
-
-#: ../../en/topology_base_types.rst:101
-msgid "geom: Geometry of the edge"
-msgstr "geom: Geometría de la arista"
-
-#: ../../en/topology_base_types.rst:104
-msgid "Abs Next Edge & Next Edge"
-msgstr "Siguientes Aristas"
-
-#: ../../en/topology_base_types.rst:106
-msgid "The table edge_data has the columns abs_next_left_edge and abs_next_right_edge, at this moment it gets a little tricky how to interpret it."
+#: ../../en/topology_topo_types.rst:51
+msgid ""
+"This concept is the one used for the user, from this point we will explain "
+"deep and technical details."
 msgstr ""
-"La tabla edge_data tiene las columnas abs_next_left_edge y "
-"abs_next_right_edge. En este momento se vuelve un poco complicado cómo "
-"interpretarlas."
 
-#: ../../en/topology_base_types.rst:108
-msgid "Until now we mainly see properties of the edge itself and what has on the sides, the next edge properties are different, do not ask only about the edge itself, it is about which is the next edge who builds the face on the right or left."
+#: ../../en/topology_topo_types.rst:53
+msgid ""
+"As a side note, Postgis Topology has internally some tricks when its about "
+"keys, helps to optimize a lot of parts but at the same time there is a lot "
+"of reduntant information, do not be supreised if you find the same "
+"information in two or more places."
 msgstr ""
-"Hasta ahora hemos visto principalmente propiedades de la arista en sí y lo "
-"que tiene a los lados. Las propiedades de la arista siguiente son "
-"diferentes, no preguntan solo por la arista en sí, sino por cuál es la "
-"siguiente arista que construye la cara a la derecha o izquierda."
 
-#: ../../en/topology_base_types.rst:110
-msgid "The logic of the right_edge and the left_edge are very similar, so we will look first on the left one deeper and then show the right one."
+#: ../../en/topology_topo_types.rst:56
+msgid "Features"
 msgstr ""
-"La lógica de right_edge y left_edge es muy similar, así que primero veremos "
-"más a fondo la izquierda y luego mostraremos la derecha."
 
-#: ../../en/topology_base_types.rst:112
-msgid "We will be using the next topology as example:"
-msgstr "Usaremos la siguiente topología como ejemplo:"
-
-#: ../../en/topology_base_types.rst:119
-msgid "Left"
-msgstr "Izquierda"
-
-#: ../../en/topology_base_types.rst:121
-msgid "Let's pick as an example the Edge 5, this one has on the Left the Face 2, looking forward which is the next edge who builds the Face 2?"
+#: ../../en/topology_topo_types.rst:58
+msgid ""
+"TopoElements can represent a TopoGeometry and a Primitive, think in a "
+"TopoGeometry, if store them in a TopoElement, they still contain other "
+"TopoElements, if we follow its path we will always ends in Primitives of the"
+" Topology."
 msgstr ""
-"Tomemos como ejemplo la Arista 5. Esta tiene a la izquierda la Cara 2. "
-"Mirando hacia adelante, ¿cuál es la siguiente arista que construye la Cara 2?"
 
-#: ../../en/topology_base_types.rst:123
-msgid "This is the Edge 6."
-msgstr "Es la Arista 6."
-
-#: ../../en/topology_base_types.rst:129
-msgid "Something very important here is the perspective we follow the lines, depending on the Edge direction, is like see the Face clockwise or anticlockwise."
+#: ../../en/topology_topo_types.rst:60
+msgid ""
+"Features will represent which type the set of geometries will be, is not "
+"important if you use TopoGeometries or Primitives, in the end a Layer can "
+"contain directly or indirectly any of this sets:"
 msgstr ""
-"Algo muy importante aquí es la perspectiva con la que seguimos las líneas. "
-"Dependiendo de la dirección de la Arista, es como ver la Cara en el sentido "
-"de las agujas del reloj o en sentido antihorario."
 
-#: ../../en/topology_base_types.rst:131
-msgid "With this information we have abs_next_left_edge which will be 6."
-msgstr "Con esta información tenemos que abs_next_left_edge será 6."
-
-#: ../../en/topology_base_types.rst:133
-msgid "The next_left_edge is almost the same as abs_next_left_edge, except it can be negative which depends on the perspective we see the edge."
+#: ../../en/topology_topo_types.rst:65
+msgid "Geometry Collections"
 msgstr ""
-"La next_left_edge es casi la misma que abs_next_left_edge, excepto que puede "
-"ser negativa, lo cual depende de la perspectiva con la que vemos la arista."
 
-#: ../../en/topology_base_types.rst:135
-msgid "If we follow the Edge perspective we will have two directions, the direction of the next edge, and the direction of the perspective on the next edge."
+#: ../../en/topology_topo_types.rst:67
+msgid ""
+"The numbers are important, in any function which requests the Feature Type, "
+"you can specify it using the number or the name as string."
 msgstr ""
-"Si seguimos la perspectiva de la Arista, tendremos dos direcciones: la "
-"dirección de la siguiente arista, y la dirección de la perspectiva en la "
-"siguiente arista."
 
-#: ../../en/topology_base_types.rst:137
-msgid "We will use the next sign in each case:"
-msgstr "Usaremos el siguiente signo en cada caso:"
-
-#: ../../en/topology_base_types.rst:139
-msgid "Perspective direction and Next edge direction are opposed: \"-\""
+#: ../../en/topology_topo_types.rst:70
+msgid "Hierarchical Layers, Childs and Parents"
 msgstr ""
-"La dirección de la perspectiva y la dirección de la siguiente arista son "
-"opuestas: \"-\""
 
-#: ../../en/topology_base_types.rst:140
-msgid "Perspective direction and Next edge direction are the same: None, keep the value positive"
+#: ../../en/topology_topo_types.rst:72
+msgid ""
+"I would like to introduce this concept later, but to explain better and "
+"deeper the concept you will find this is needed."
 msgstr ""
-"La dirección de la perspectiva y la dirección de la siguiente arista son las "
-"mismas: Ninguno, mantener el valor positivo"
 
-#: ../../en/topology_base_types.rst:142
-msgid "How the Perspective and Edge 6 have the same direction, next_left_edge will be 6."
+#: ../../en/topology_topo_types.rst:77
+msgid ""
+"The first aspect on the image is a table that is constructed using "
+"Primitives, Layer 1 will have TopoGeometries where its TopoElements only "
+"make a reference to Primitives of the topology."
 msgstr ""
-"Como la Perspectiva y la Arista 6 tienen la misma dirección, next_left_edge "
-"será 6."
 
-#: ../../en/topology_base_types.rst:144
-msgid "abs_next_left_edge: 6"
-msgstr "abs_next_left_edge: 6"
-
-#: ../../en/topology_base_types.rst:145
-msgid "next_left_edge: 6"
-msgstr "next_left_edge: 6"
-
-#: ../../en/topology_base_types.rst:148
-msgid "Right"
-msgstr "Derecha"
-
-#: ../../en/topology_base_types.rst:150
-msgid "The only difference between Left and Right analysis is the perspective, while in Left we use forward, in Right we will see backwards. Be careful, even if we look backwards the definition of Left Face and Right Face are still the same, looking forward! Only changes the perspective to follow."
+#: ../../en/topology_topo_types.rst:79
+msgid "We define the relationship between Layer 1 and Primitives as:"
 msgstr ""
-"La única diferencia entre el análisis Izquierda y Derecha es la perspectiva. "
-"Mientras que en Izquierda usamos hacia adelante, en Derecha veremos hacia "
-"atrás. Ten cuidado: incluso si miramos hacia atrás, la definición de Cara "
-"Izquierda y Cara Derecha sigue siendo la misma, mirando hacia adelante. Solo "
-"cambia la perspectiva a seguir."
 
-#: ../../en/topology_base_types.rst:152
-msgid "The Edge 5 has the Face 0 on its Right, the Universal Face, looking Edge 5 backwards the next edge who builds Face 0 is the Edge 4."
+#: ../../en/topology_topo_types.rst:81
+msgid "Layer 1 is Parent of the Primitives"
 msgstr ""
-"La Arista 5 tiene la Cara 0 a su derecha, la Cara Universal. Mirando la "
-"Arista 5 hacia atrás, la siguiente arista que construye la Cara 0 es la "
-"Arista 4."
 
-#: ../../en/topology_base_types.rst:158
-msgid "Following the perspective of Edge 5 on Edge 4 we can see it goes up, while the Edge 4 goes down, the Perspective direction and the Edge 4 direction are opposed."
+#: ../../en/topology_topo_types.rst:82
+msgid "Primitives are Childs of the Layer 1"
 msgstr ""
-"Siguiendo la perspectiva de la Arista 5 en la Arista 4, vemos que va hacia "
-"arriba, mientras que la Arista 4 va hacia abajo. La dirección de la "
-"Perspectiva y la dirección de la Arista 4 son opuestas."
 
-#: ../../en/topology_base_types.rst:160
-msgid "abs_next_right_edge: 4"
-msgstr "abs_next_right_edge: 4"
-
-#: ../../en/topology_base_types.rst:161
-msgid "next_right_edge: -4 (Perspective direction and Edge 4 direction are opposed)"
+#: ../../en/topology_topo_types.rst:84
+msgid ""
+"The relation between Parent and Child is about the size, Childs are small, "
+"when we have a group of them we build a Parent, a bigger group."
 msgstr ""
-"next_right_edge: -4 (La dirección de la Perspectiva y la dirección de la "
-"Arista 4 son opuestas)"
 
-#: ../../en/topology_base_types.rst:164
-msgid "Isolated Edge Case"
-msgstr "Caso de Arista Aislada"
-
-#: ../../en/topology_base_types.rst:166
-msgid "There is a case that may be confusing, all the rules above follow in the same way but it is good to take a look."
+#: ../../en/topology_topo_types.rst:86
+msgid ""
+"Layer 2 has as childs the Layer 1, this implies each TopoGeometry from this "
+"layer, can make a reference to one or multiple TopoGeometries of the Layer "
+"1."
 msgstr ""
-"Hay un caso que puede ser confuso. Todas las reglas anteriores se siguen de "
-"la misma manera, pero es bueno revisarlo."
 
-#: ../../en/topology_base_types.rst:172
-msgid "When we have an Edge that has no connections to other Edges, the first thing we can appreciate is that the Face of the Left is the same as the Right, in this case Face 0, the Universal Face."
+#: ../../en/topology_topo_types.rst:88
+msgid ""
+"This also means you can't pick half of a TopoGeometry from Layer 1, pick "
+"half of it means you need a reference to one of the TopoElements of a "
+"TopoGeometry, which in this case belongs to the Primitives (its Child), if "
+"you really need that then build Layer 2 using Layer 1 childs (Primitives)."
 msgstr ""
-"Cuando tenemos una Arista que no tiene conexión con otras Aristas, lo "
-"primero que podemos apreciar es que la Cara de la Izquierda es la misma que "
-"la de la Derecha, en este caso la Cara 0, la Cara Universal."
 
-#: ../../en/topology_base_types.rst:174
-msgid "If we follow the past logic, on the Left is the Face 0, which is the next edge who builds Face 0? Actually there is an Edge, and is itself, and it also has a perspective as before:"
+#: ../../en/topology_topo_types.rst:90
+msgid ""
+"Each Layer can only have one Child Layer, this means, the Child and Parent "
+"share the same Topology schema."
 msgstr ""
-"Si seguimos la lógica anterior, a la izquierda está la Cara 0. ¿Cuál es la "
-"siguiente arista que construye la Cara 0? En realidad hay una arista, y es "
-"ella misma, y también tiene una perspectiva como antes:"
 
-#: ../../en/topology_base_types.rst:180
-msgid "If we check the perspective direction we ends looking the same edge but in opposite direction, this means the Edge 1 and its Next Edge (Edge 1) has opposed directions."
+#: ../../en/topology_topo_types.rst:92
+msgid ""
+"You will notice some aspects of Hierarchy could change to maybe support "
+"something like half TopoGeometry or mixing Layers, but right now is not "
+"implemented."
 msgstr ""
-"Si revisamos la dirección de la perspectiva, terminamos viendo la misma "
-"arista pero en dirección opuesta. Esto significa que la Arista 1 y su "
-"Siguiente Arista (Arista 1) tienen direcciones opuestas."
 
-#: ../../en/topology_base_types.rst:182
-#: ../../en/topology_base_types.rst:194
-msgid "edge_id: 1"
-msgstr "edge_id: 1"
-
-#: ../../en/topology_base_types.rst:183
-msgid "abs_next_left_edge: 1"
-msgstr "abs_next_left_edge: 1"
-
-#: ../../en/topology_base_types.rst:184
-msgid "next_left_edge: -1 (This will always be negative while we see forward a isolated edge)"
+#: ../../en/topology_topo_types.rst:95
+msgid "Layers"
 msgstr ""
-"next_left_edge: -1 (Esto siempre será negativo mientras veamos hacia "
-"adelante una arista aislada)"
 
-#: ../../en/topology_base_types.rst:186
-msgid "For the Next Right Edge is the same, the Next Edge will be it self, the only what it changes is the perspective:"
+#: ../../en/topology_topo_types.rst:97
+msgid ""
+"To store TopoGeometries we need a Layer, due to this when we create a "
+"TopoGeometrie's Column, we also create a Layer, this is why we use a special"
+" function to create a column for this."
 msgstr ""
-"Para la Next Right Edge es lo mismo. La siguiente arista será ella misma, lo "
-"único que cambia es la perspectiva:"
 
-#: ../../en/topology_base_types.rst:192
-msgid "When we look backwards any isolated edge, the perspective will always have the same direction as the Edge so:"
+#: ../../en/topology_topo_types.rst:99
+msgid ""
+"`Crete TopoGeometry Column "
+"<https://postgis.net/docs/AddTopoGeometryColumn.html>`_"
 msgstr ""
-"Cuando miramos hacia atrás cualquier arista aislada, la perspectiva siempre "
-"tendrá la misma dirección que la Arista, así que:"
 
-#: ../../en/topology_base_types.rst:195
-msgid "abs_next_right_edge: 1"
-msgstr "abs_next_right_edge: 1"
-
-#: ../../en/topology_base_types.rst:196
-msgid "next_right_edge: -1 (This will always be positive while we see backwar a isolated edge)"
+#: ../../en/topology_topo_types.rst:101
+msgid ""
+"Layers and TopoGeometry Columns have a special relationship, they are "
+"linked, but they are not the same."
 msgstr ""
-"next_right_edge: -1 (Esto siempre será positivo mientras veamos hacia atrás "
-"una arista aislada)"
 
-#: ../../en/topology_base_types.rst:199
-msgid "Full columns of edge_data"
-msgstr "Columnas de la tabla edge_data"
-
-#: ../../en/topology_base_types.rst:201
-msgid "We already checked all the columns of the edge_data table:"
-msgstr "Ya hemos revisado todas las columnas de la tabla edge_data:"
-
-#: ../../en/topology_base_types.rst:203
-msgid "edge_id: Unique ID for the edge."
-msgstr "edge_id: ID único para la arista."
-
-#: ../../en/topology_base_types.rst:204
-msgid "start_node: ID for the node which is the same as the start point of the edge."
+#: ../../en/topology_topo_types.rst:103
+msgid ""
+"Layers have a lot of information that we must provide to know which type of "
+"Layer we want."
 msgstr ""
-"start_node: ID del nodo que es el mismo que el punto inicial de la arista."
 
-#: ../../en/topology_base_types.rst:205
-msgid "end_node: ID for the node which is the same as the end point of the edge."
-msgstr "end_node: ID del nodo que es el mismo que el punto final de la arista."
-
-#: ../../en/topology_base_types.rst:206
-msgid "left_face: ID of the face on the left of the edge."
-msgstr "left_face: ID de la cara a la izquierda de la arista."
-
-#: ../../en/topology_base_types.rst:207
-msgid "abs_next_left_edge: Next edge who builds the face on the left."
+#: ../../en/topology_topo_types.rst:105
+msgid ""
+"Layers have a unique identifier in each topology, this identifier is called "
+"layer_id."
 msgstr ""
-"abs_next_left_edge: Siguiente arista que construye la cara en la izquierda."
 
-#: ../../en/topology_base_types.rst:208
-msgid "next_left_edge: abs_next_left_edge and negative sign if the right face is on the right of the next left edge."
+#: ../../en/topology_topo_types.rst:107
+msgid "Layers Key: Composed Key with [topology_id, layer_id]"
 msgstr ""
-"next_left_edge: abs_next_left_edge y signo negativo si la cara derecha está "
-"a la derecha de la siguiente arista izquierda."
 
-#: ../../en/topology_base_types.rst:209
-msgid "right_face: ID of the face on the right of the edge."
-msgstr "right_face: ID de la cara a la derecha de la arista."
-
-#: ../../en/topology_base_types.rst:210
-msgid "abs_next_right_edge: Next edge who builds the face on the right."
+#: ../../en/topology_topo_types.rst:108
+msgid ""
+"Table route: Schema name, table name and column name to know where it is "
+"linked."
 msgstr ""
-"abs_next_right_edge: Siguiente arista que construye la cara en la derecha."
 
-#: ../../en/topology_base_types.rst:211
-msgid "next_right_edge: abs_next_right_edge and negative sign if the left face is on the right of the next right edge."
+#: ../../en/topology_topo_types.rst:109
+msgid "Feature Type: Feature type the layer will contain."
 msgstr ""
-"next_right_edge: abs_next_right_edge y signo negativo si la cara izquierda "
-"está a la derecha de la siguiente arista derecha."
 
-#: ../../en/topology_base_types.rst:212
-msgid "geom: Geometry of the edge."
-msgstr "geom: Geometría de la arista."
+#: ../../en/topology_topo_types.rst:110
+msgid ""
+"Level: This value starts at 0, in the case we construct this layer using "
+"another layer, it will add 1, so we know how many layers we are from the "
+"Primitives, if the value is 0 means the Layer is constructed using "
+"Primitives instead of TopoGeometries."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:111
+msgid ""
+"child_id: In case the layer is built not using Primitives and using another "
+"Layer as base, we need the Layer Identifier (layer_id) of this layer, we do "
+"not need topology_id because we already know it from the parent."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:114
+msgid "Relation's Table"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:116
+msgid ""
+"Finally, the section you may be looking at, how Postgis Topology goes from a"
+" TopoGeometry to what they contain."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:118
+msgid ""
+"The Relation's table function is be the bridge between the Parent and "
+"Childs."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:120
+msgid "This table can be found in: ``my_topology.relation``."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:123
+msgid "Keys and Identifiers we know now"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:125
+msgid ""
+"I'll use the word \"Identifier\" as a unique key in a particular context. "
+"For example each layer has a number as an identifier (layer_id), it is "
+"unique in its topology context, but is not enough to find a layer in a "
+"database."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:127
+msgid ""
+"While Identifiers will work in a context, the Key will be the full way to "
+"address an element, for example the key for any layer are two values "
+"[topology_id, layer_id]."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:133
+msgid "The image is a good summary of how the keys for each are composed."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:136
+msgid "Implicit identifiers on Keys"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:138
+msgid ""
+"Postgis uses at some extent an implicit logic when working with Layers and "
+"TopoGeometries, this is because they have a context where you don't need to "
+"store the full Key to know it."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:140
+msgid "To show an example:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:142
+msgid "TopoGeometry is composed by:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:144
+msgid "topology_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:145
+msgid "layer_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:146
+msgid "topogeometry_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:148
+msgid ""
+"As we said before, the relation's table is stored inside the topology "
+"schema. This table will contain the relation of the TopoGeometry with the "
+"TopoElements, to make a reference in this context, do we need the "
+"topology_id?"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:150
+msgid ""
+"We can skip it! While we are out of the topology schema we need the id to "
+"find it, but while we are inside it we can look at the schema name, and find"
+" its id on the table ``topology.topology``, which has all topologies ids and"
+" names."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:153
+msgid "TopoGeometry"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:155
+msgid "TopoGeometry is a composite key with the next elements:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:157
+msgid "topology_id: topology_id of TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:158
+msgid "layer_id: layer_id of the TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:159
+msgid "id: topogeometry_id of the TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:160
+msgid "type: Feature type as number"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:163
+msgid "Basic Relation's table structure"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:165
+msgid ""
+"Each schema topology can have its own relation's table, it will be created "
+"when you create your first TopoGeometry, the table is stored inside the "
+"topology as ``custom_topology.relation``."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:167
+msgid ""
+"Each row of the table is called a \"Component\", like a component of the "
+"relations."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:169
+msgid ""
+"The component saves pairs of two things, a TopoGeometry Key and a "
+"TopoElement, remember that each TopoElement can only represent one Primitive"
+" or TopoGeometry, so for a TopoGeometry be able to represent several of them"
+" the tables stores multiple rows with the same TopoGeometry Key and "
+"different TopoElements, this way only filtering in the table we can get all "
+"the TopoElements for any TopoGeometry."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:176
+msgid "Find Components of a TopoGeometry"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:178
+msgid ""
+"To find which components belong to a TopoGeometry is a little tricky, "
+"because here will work the implicit Keys."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:180
+msgid "A component has the next elements:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:182
+msgid "TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:184
+msgid "topogeom_id: topogeometry_id from TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:185
+msgid "layer_id: layer_id from TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:187
+msgid "TopoElement"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:189
+msgid "element_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:190
+msgid "element_type"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:192
+msgid ""
+"We can notice the TopoGeometry Key is incomplete, this is because the "
+"relation's table already belongs to a topology, so there is no need to store"
+" the topology identifier again."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:194
+msgid ""
+"To reach from a TopoGeometry to a Component we need to look the "
+"TopoGeometry.topology_id and search on ``topology.topology.id`` and retrieve"
+" the Topology Name, with it we can found the relation's table in their "
+"respective schema."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:201
+msgid "Reading TopoElements"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:203
+msgid ""
+"The last part to decompose TopoGeometry is to be able to interpret the "
+"TopoElements which is more complex than other keys, because its meaning can "
+"change based on the Layer it is saved."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:205
+msgid ""
+"As we talked, a Layer can have as Childs two options, Primitives or "
+"TopoGeometries."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:207
+msgid ""
+"The first we need to know is which Childs it is using, for this we need to "
+"look on ``topology.layer.id`` using the ``TopoGeometry Key.layer_id`` and "
+"get ```topology.layer.child_id```."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:209
+msgid "So the cases depends on child_id:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:211
+msgid "If is NULL:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:213
+msgid "element_id: Primitive Identifier"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:214
+msgid ""
+"element_type: Feature number, look on the Features to know to which "
+"primitive table too look on."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:216
+msgid "If is not NULL:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:218
+msgid "element_id: topogeometry_id from a TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:219
+msgid "element_type: layer_id from a TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:221
+msgid ""
+"The first case is trivial, just look at their respective Primitive table and"
+" use the identifier to know which primitive is."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:223
+msgid ""
+"While the second case the TopoElement is used to build a new TopoGeometry "
+"Key, the topology_id is implicit as we talked, so the Key is complete, to "
+"find the new elements look again on the relation's table but using the new "
+"keys."
+msgstr ""
+
+#~ msgid "Topology Basic Types"
+#~ msgstr "Tipos Básicos de Topología"
+
+#~ msgid ""
+#~ "`ISO Topology: OGC-SFS Geometries <https://www.gaia-"
+#~ "gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+#~ msgstr ""
+#~ "`Topología en ISO: Geometrías OGC-SFS <https://www.gaia-"
+#~ "gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+
+#~ msgid ""
+#~ "In this workshop, we will check some fundamentals of topology, its basics "
+#~ "and definitions. It is not intended to be a way to use them directly, is to "
+#~ "understand it to then be able to use it easily."
+#~ msgstr ""
+#~ "En este taller revisaremos algunos fundamentos de topología, sus bases y "
+#~ "definiciones. No pretende ser una forma de utilizarlos directamente, es "
+#~ "entenderlo para luego poder utilizarlo fácilmente."
+
+#~ msgid "Types"
+#~ msgstr "Tipos"
+
+#~ msgid "The basic topology works on three basic types."
+#~ msgstr "La topología básica funciona con tres tipos básicos."
+
+#~ msgid "Node: 2D point, everything starts or ends here"
+#~ msgstr "Nodo: punto 2D, todo empieza o acaba aquí"
+
+#~ msgid "Edge: A linestring with direction that start and ends on a node"
+#~ msgstr "Arista: línea con dirección que comienza y termina en un nodo"
+
+#~ msgid "Face: Closed set of linestrings, that conforms a polygon"
+#~ msgstr ""
+#~ "Cara (Face): Conjunto cerrado de líneas (linestrings), que conforma un "
+#~ "polígono"
+
+#~ msgid ""
+#~ "There are some rules for a set of nodes, edges and faces to be valid, check "
+#~ "the ISO Topology document, has a very good summary of these conditions, a "
+#~ "topology that follows all the rules, is a valid topology."
+#~ msgstr ""
+#~ "Existen algunas reglas para que un conjunto de nodos, aristas y caras sea "
+#~ "válido. Revisa el documento ISO Topology, que tiene un muy buen resumen de "
+#~ "estas condiciones. Una topología que sigue todas las reglas es una topología"
+#~ " válida."
+
+#~ msgid ""
+#~ "Is good to know, until now Postgis will save all this information "
+#~ "internally, each type has its own unique ID, and with it we can edit and "
+#~ "change them using the available functions, for example with "
+#~ "ST_RemEdgeNewFace you can remove an edge and create a new face."
+#~ msgstr ""
+#~ "Es bueno saber que, hasta ahora, PostGIS guardará toda esta información "
+#~ "internamente, cada tipo tiene su propio ID único, y con él podemos editarlos"
+#~ " y modificarlos usando las funciones disponibles. Por ejemplo, con "
+#~ "ST_RemEdgeNewFace puedes eliminar una arista y crear una nueva cara."
+
+#~ msgid ""
+#~ "But there is still a missing piece, how do we say for example, a face has a "
+#~ "specific attribute? Postgis implements several concepts to do this like "
+#~ "Layers, TopoGeometry, TopoElement."
+#~ msgstr ""
+#~ "Pero aún falta una pieza: ¿cómo decimos, por ejemplo, que una cara tiene un "
+#~ "atributo específico? PostGIS implementa varios conceptos para hacer esto "
+#~ "como Layers, TopoGeometry, TopoElement."
+
+#~ msgid "Universal Face"
+#~ msgstr "Cara Universal"
+
+#~ msgid ""
+#~ "It Might be intuitive to think that only the faces constructed by edges "
+#~ "exist, there is one exception, all the white space out of all the faces is "
+#~ "also a face!"
+#~ msgstr ""
+#~ "Podría ser intuitivo pensar que solo existen las caras construidas por "
+#~ "aristas, pero hay una excepción: ¡todo el espacio en blanco fuera de todas "
+#~ "las caras también es una cara!"
+
+#~ msgid ""
+#~ "The empty space is called the Universal Face, when a Topology is empty, all "
+#~ "the space is the Universal Face, when we add a linestring is an edge of this"
+#~ " face, then when we make a polygon it is like make a hole in the face and "
+#~ "stealing it to assign it to a face."
+#~ msgstr ""
+#~ "El espacio vacío se llama la Cara Universal. Cuando una topología está "
+#~ "vacía, todo el espacio es la Cara Universal. Cuando añadimos una línea "
+#~ "(linestring), esta es una arista de esa cara; luego, cuando creamos un "
+#~ "polígono, es como hacer un agujero en la cara y “robarlo” para asignarlo a "
+#~ "una cara."
+
+#~ msgid "This face is infinite and does not have any boundary."
+#~ msgstr "Esta cara es infinita y no tiene ningún límite."
+
+#~ msgid "The Universal Face has the ID 0."
+#~ msgstr "La Cara Universal tiene el ID 0."
+
+#~ msgid "Edge interpretation"
+#~ msgstr "Interpretación de Aristas"
+
+#~ msgid ""
+#~ "To correctly represent a topology and their forms, there are some "
+#~ "definitions that are used to construct the tables that store everything, the"
+#~ " edge is on the more complex ones."
+#~ msgstr ""
+#~ "Para representar correctamente una topología y sus formas, hay algunas "
+#~ "definiciones que se usan para construir las tablas que almacenan todo. La "
+#~ "arista es una de las más complejas."
+
+#~ msgid ""
+#~ "All the information about edges is stored on the edge_data table, in your "
+#~ "custom topology schema, and which information do we need in the edges? "
+#~ "basically its nodes and faces information, edge is the primitive who "
+#~ "connects both."
+#~ msgstr ""
+#~ "Toda la información sobre las aristas se almacena en la tabla edge_data, en "
+#~ "tu esquema de topología personalizada. ¿Y qué información necesitamos en las"
+#~ " aristas? Básicamente la información de sus nodos y caras. La arista es la "
+#~ "primitiva que conecta ambos."
+
+#~ msgid ""
+#~ "These linestrings are called Edges because they are the edges of the faces."
+#~ msgstr "Estas líneas se llaman Aristas porque son los bordes de las caras."
+
+#~ msgid "Edge direction, left and right"
+#~ msgstr "Dirección de la arista, izquierda y derecha"
+
+#~ msgid ""
+#~ "Edges in topology has a right defined perspective and view, when we see them"
+#~ " must be done in the next way:"
+#~ msgstr ""
+#~ "Las aristas en topología tienen una perspectiva y orientación definidas. "
+#~ "Cuando las vemos, debe hacerse de la siguiente manera:"
+
+#~ msgid ""
+#~ "When we want to see from the edge perspective is always from the end node to"
+#~ " the start edge, always looking the edge forward."
+#~ msgstr ""
+#~ "Cuando queremos ver desde la perspectiva de la arista, siempre es desde el "
+#~ "nodo final hacia el nodo inicial, siempre mirando hacia adelante en la "
+#~ "arista."
+
+#~ msgid ""
+#~ "The edges have left and right properties, as we see they are defined using "
+#~ "the edge perspective, see the linestring from the start node to the end "
+#~ "node, there will always be a well defined left and right."
+#~ msgstr ""
+#~ "Las aristas tienen propiedades de izquierda y derecha. Como vemos, estas se "
+#~ "definen usando la perspectiva de la arista: mirando la línea desde el nodo "
+#~ "inicial hacia el nodo final, siempre habrá un lado izquierdo y un lado "
+#~ "derecho bien definidos."
+
+#~ msgid "So see the edge forward and you always have a left and right side."
+#~ msgstr ""
+#~ "Así que mira la arista hacia adelante y siempre tendrás un lado izquierdo y "
+#~ "uno derecho."
+
+#~ msgid "This helps to relate which faces are on each side of the edge:"
+#~ msgstr "Esto ayuda a relacionar qué caras están en cada lado de la arista:"
+
+#~ msgid ""
+#~ "Check the edges on the image, while almost all the edges go from down to up "
+#~ "and left to right, there is an orange edge which has the opposite direction,"
+#~ " so its sides left and right are swapped in reference to the others, but if "
+#~ "you look the edge forward, the right and left are right."
+#~ msgstr ""
+#~ "Observa las aristas en la imagen: aunque casi todas van de abajo hacia "
+#~ "arriba y de izquierda a derecha, hay una arista naranja que tiene la "
+#~ "dirección opuesta, por lo que sus lados izquierdo y derecho están invertidos"
+#~ " con respecto a las demás. Pero si miras la arista hacia adelante, el lado "
+#~ "derecho e izquierdo son correctos."
+
+#~ msgid ""
+#~ "Continue seeing the orange edge, while on its right has a polygon built by "
+#~ "the edges, on the left is the Universal Face."
+#~ msgstr ""
+#~ "Siguiendo con la arista naranja, mientras que a su derecha tiene un polígono"
+#~ " construido por las aristas, a la izquierda está la Cara Universal."
+
+#~ msgid ""
+#~ "When we want to analyze any edge, and we need to see it from the edge "
+#~ "perspective, it is always looking the edge in forward, never in backward!"
+#~ msgstr ""
+#~ "Cuando queremos analizar cualquier arista, y necesitamos verla desde la "
+#~ "perspectiva de la arista, siempre es mirándola hacia adelante, ¡nunca hacia "
+#~ "atrás!"
+
+#~ msgid ""
+#~ "Which are all the next edges? Looking forward we go from start node to the "
+#~ "end node, all the edges who start or end in the end node of the edge!"
+#~ msgstr ""
+#~ "¿Cuáles son las siguientes aristas? Mirando hacia adelante vamos del nodo "
+#~ "inicial al nodo final, ¡todas las aristas que comienzan o terminan en el "
+#~ "nodo final de la arista!"
+
+#~ msgid "Edge Data"
+#~ msgstr "Datos de la Arista"
+
+#~ msgid ""
+#~ "The edge_data table has information related to the edge, from what we know "
+#~ "right now we can interpret the next columns:"
+#~ msgstr ""
+#~ "La tabla edge_data tiene información relacionada con la arista. A partir de "
+#~ "lo que sabemos hasta ahora, podemos interpretar las siguientes columnas:"
+
+#~ msgid "edge_id: Unique ID for the edge"
+#~ msgstr "edge_id: ID único para la arista"
+
+#~ msgid ""
+#~ "start_node: ID for the node who is the same as the start point of the edge"
+#~ msgstr ""
+#~ "start_node: ID del nodo que es el mismo que el punto inicial de la arista"
+
+#~ msgid "end_node: ID for the node who is the same as the end point of the edge"
+#~ msgstr "end_node: ID del nodo que es el mismo que el punto final de la arista"
+
+#~ msgid "left_face: ID of the face on the left of the edge"
+#~ msgstr "left_face: ID de la cara a la izquierda de la arista"
+
+#~ msgid "right_face: ID of the face on the right of the edge"
+#~ msgstr "right_face: ID de la cara a la derecha de la arista"
+
+#~ msgid "Abs Next Edge & Next Edge"
+#~ msgstr "Siguientes Aristas"
+
+#~ msgid ""
+#~ "The table edge_data has the columns abs_next_left_edge and "
+#~ "abs_next_right_edge, at this moment it gets a little tricky how to interpret"
+#~ " it."
+#~ msgstr ""
+#~ "La tabla edge_data tiene las columnas abs_next_left_edge y "
+#~ "abs_next_right_edge. En este momento se vuelve un poco complicado cómo "
+#~ "interpretarlas."
+
+#~ msgid ""
+#~ "Until now we mainly see properties of the edge itself and what has on the "
+#~ "sides, the next edge properties are different, do not ask only about the "
+#~ "edge itself, it is about which is the next edge who builds the face on the "
+#~ "right or left."
+#~ msgstr ""
+#~ "Hasta ahora hemos visto principalmente propiedades de la arista en sí y lo "
+#~ "que tiene a los lados. Las propiedades de la arista siguiente son "
+#~ "diferentes, no preguntan solo por la arista en sí, sino por cuál es la "
+#~ "siguiente arista que construye la cara a la derecha o izquierda."
+
+#~ msgid ""
+#~ "The logic of the right_edge and the left_edge are very similar, so we will "
+#~ "look first on the left one deeper and then show the right one."
+#~ msgstr ""
+#~ "La lógica de right_edge y left_edge es muy similar, así que primero veremos "
+#~ "más a fondo la izquierda y luego mostraremos la derecha."
+
+#~ msgid "We will be using the next topology as example:"
+#~ msgstr "Usaremos la siguiente topología como ejemplo:"
+
+#~ msgid "Left"
+#~ msgstr "Izquierda"
+
+#~ msgid ""
+#~ "Let's pick as an example the Edge 5, this one has on the Left the Face 2, "
+#~ "looking forward which is the next edge who builds the Face 2?"
+#~ msgstr ""
+#~ "Tomemos como ejemplo la Arista 5. Esta tiene a la izquierda la Cara 2. "
+#~ "Mirando hacia adelante, ¿cuál es la siguiente arista que construye la Cara "
+#~ "2?"
+
+#~ msgid "This is the Edge 6."
+#~ msgstr "Es la Arista 6."
+
+#~ msgid ""
+#~ "Something very important here is the perspective we follow the lines, "
+#~ "depending on the Edge direction, is like see the Face clockwise or "
+#~ "anticlockwise."
+#~ msgstr ""
+#~ "Algo muy importante aquí es la perspectiva con la que seguimos las líneas. "
+#~ "Dependiendo de la dirección de la Arista, es como ver la Cara en el sentido "
+#~ "de las agujas del reloj o en sentido antihorario."
+
+#~ msgid "With this information we have abs_next_left_edge which will be 6."
+#~ msgstr "Con esta información tenemos que abs_next_left_edge será 6."
+
+#~ msgid ""
+#~ "The next_left_edge is almost the same as abs_next_left_edge, except it can "
+#~ "be negative which depends on the perspective we see the edge."
+#~ msgstr ""
+#~ "La next_left_edge es casi la misma que abs_next_left_edge, excepto que puede"
+#~ " ser negativa, lo cual depende de la perspectiva con la que vemos la arista."
+
+#~ msgid ""
+#~ "If we follow the Edge perspective we will have two directions, the direction"
+#~ " of the next edge, and the direction of the perspective on the next edge."
+#~ msgstr ""
+#~ "Si seguimos la perspectiva de la Arista, tendremos dos direcciones: la "
+#~ "dirección de la siguiente arista, y la dirección de la perspectiva en la "
+#~ "siguiente arista."
+
+#~ msgid "We will use the next sign in each case:"
+#~ msgstr "Usaremos el siguiente signo en cada caso:"
+
+#~ msgid "Perspective direction and Next edge direction are opposed: \"-\""
+#~ msgstr ""
+#~ "La dirección de la perspectiva y la dirección de la siguiente arista son "
+#~ "opuestas: \"-\""
+
+#~ msgid ""
+#~ "Perspective direction and Next edge direction are the same: None, keep the "
+#~ "value positive"
+#~ msgstr ""
+#~ "La dirección de la perspectiva y la dirección de la siguiente arista son las"
+#~ " mismas: Ninguno, mantener el valor positivo"
+
+#~ msgid ""
+#~ "How the Perspective and Edge 6 have the same direction, next_left_edge will "
+#~ "be 6."
+#~ msgstr ""
+#~ "Como la Perspectiva y la Arista 6 tienen la misma dirección, next_left_edge "
+#~ "será 6."
+
+#~ msgid "abs_next_left_edge: 6"
+#~ msgstr "abs_next_left_edge: 6"
+
+#~ msgid "next_left_edge: 6"
+#~ msgstr "next_left_edge: 6"
+
+#~ msgid "Right"
+#~ msgstr "Derecha"
+
+#~ msgid ""
+#~ "The only difference between Left and Right analysis is the perspective, "
+#~ "while in Left we use forward, in Right we will see backwards. Be careful, "
+#~ "even if we look backwards the definition of Left Face and Right Face are "
+#~ "still the same, looking forward! Only changes the perspective to follow."
+#~ msgstr ""
+#~ "La única diferencia entre el análisis Izquierda y Derecha es la perspectiva."
+#~ " Mientras que en Izquierda usamos hacia adelante, en Derecha veremos hacia "
+#~ "atrás. Ten cuidado: incluso si miramos hacia atrás, la definición de Cara "
+#~ "Izquierda y Cara Derecha sigue siendo la misma, mirando hacia adelante. Solo"
+#~ " cambia la perspectiva a seguir."
+
+#~ msgid ""
+#~ "The Edge 5 has the Face 0 on its Right, the Universal Face, looking Edge 5 "
+#~ "backwards the next edge who builds Face 0 is the Edge 4."
+#~ msgstr ""
+#~ "La Arista 5 tiene la Cara 0 a su derecha, la Cara Universal. Mirando la "
+#~ "Arista 5 hacia atrás, la siguiente arista que construye la Cara 0 es la "
+#~ "Arista 4."
+
+#~ msgid ""
+#~ "Following the perspective of Edge 5 on Edge 4 we can see it goes up, while "
+#~ "the Edge 4 goes down, the Perspective direction and the Edge 4 direction are"
+#~ " opposed."
+#~ msgstr ""
+#~ "Siguiendo la perspectiva de la Arista 5 en la Arista 4, vemos que va hacia "
+#~ "arriba, mientras que la Arista 4 va hacia abajo. La dirección de la "
+#~ "Perspectiva y la dirección de la Arista 4 son opuestas."
+
+#~ msgid "abs_next_right_edge: 4"
+#~ msgstr "abs_next_right_edge: 4"
+
+#~ msgid ""
+#~ "next_right_edge: -4 (Perspective direction and Edge 4 direction are opposed)"
+#~ msgstr ""
+#~ "next_right_edge: -4 (La dirección de la Perspectiva y la dirección de la "
+#~ "Arista 4 son opuestas)"
+
+#~ msgid "Isolated Edge Case"
+#~ msgstr "Caso de Arista Aislada"
+
+#~ msgid ""
+#~ "There is a case that may be confusing, all the rules above follow in the "
+#~ "same way but it is good to take a look."
+#~ msgstr ""
+#~ "Hay un caso que puede ser confuso. Todas las reglas anteriores se siguen de "
+#~ "la misma manera, pero es bueno revisarlo."
+
+#~ msgid ""
+#~ "When we have an Edge that has no connections to other Edges, the first thing"
+#~ " we can appreciate is that the Face of the Left is the same as the Right, in"
+#~ " this case Face 0, the Universal Face."
+#~ msgstr ""
+#~ "Cuando tenemos una Arista que no tiene conexión con otras Aristas, lo "
+#~ "primero que podemos apreciar es que la Cara de la Izquierda es la misma que "
+#~ "la de la Derecha, en este caso la Cara 0, la Cara Universal."
+
+#~ msgid ""
+#~ "If we follow the past logic, on the Left is the Face 0, which is the next "
+#~ "edge who builds Face 0? Actually there is an Edge, and is itself, and it "
+#~ "also has a perspective as before:"
+#~ msgstr ""
+#~ "Si seguimos la lógica anterior, a la izquierda está la Cara 0. ¿Cuál es la "
+#~ "siguiente arista que construye la Cara 0? En realidad hay una arista, y es "
+#~ "ella misma, y también tiene una perspectiva como antes:"
+
+#~ msgid ""
+#~ "If we check the perspective direction we ends looking the same edge but in "
+#~ "opposite direction, this means the Edge 1 and its Next Edge (Edge 1) has "
+#~ "opposed directions."
+#~ msgstr ""
+#~ "Si revisamos la dirección de la perspectiva, terminamos viendo la misma "
+#~ "arista pero en dirección opuesta. Esto significa que la Arista 1 y su "
+#~ "Siguiente Arista (Arista 1) tienen direcciones opuestas."
+
+#~ msgid "edge_id: 1"
+#~ msgstr "edge_id: 1"
+
+#~ msgid "abs_next_left_edge: 1"
+#~ msgstr "abs_next_left_edge: 1"
+
+#~ msgid ""
+#~ "next_left_edge: -1 (This will always be negative while we see forward a "
+#~ "isolated edge)"
+#~ msgstr ""
+#~ "next_left_edge: -1 (Esto siempre será negativo mientras veamos hacia "
+#~ "adelante una arista aislada)"
+
+#~ msgid ""
+#~ "For the Next Right Edge is the same, the Next Edge will be it self, the only"
+#~ " what it changes is the perspective:"
+#~ msgstr ""
+#~ "Para la Next Right Edge es lo mismo. La siguiente arista será ella misma, lo"
+#~ " único que cambia es la perspectiva:"
+
+#~ msgid ""
+#~ "When we look backwards any isolated edge, the perspective will always have "
+#~ "the same direction as the Edge so:"
+#~ msgstr ""
+#~ "Cuando miramos hacia atrás cualquier arista aislada, la perspectiva siempre "
+#~ "tendrá la misma dirección que la Arista, así que:"
+
+#~ msgid "abs_next_right_edge: 1"
+#~ msgstr "abs_next_right_edge: 1"
+
+#~ msgid ""
+#~ "next_right_edge: -1 (This will always be positive while we see backwar a "
+#~ "isolated edge)"
+#~ msgstr ""
+#~ "next_right_edge: -1 (Esto siempre será positivo mientras veamos hacia atrás "
+#~ "una arista aislada)"
+
+#~ msgid "Full columns of edge_data"
+#~ msgstr "Columnas de la tabla edge_data"
+
+#~ msgid "We already checked all the columns of the edge_data table:"
+#~ msgstr "Ya hemos revisado todas las columnas de la tabla edge_data:"
+
+#~ msgid "edge_id: Unique ID for the edge."
+#~ msgstr "edge_id: ID único para la arista."
+
+#~ msgid ""
+#~ "start_node: ID for the node which is the same as the start point of the "
+#~ "edge."
+#~ msgstr ""
+#~ "start_node: ID del nodo que es el mismo que el punto inicial de la arista."
+
+#~ msgid ""
+#~ "end_node: ID for the node which is the same as the end point of the edge."
+#~ msgstr ""
+#~ "end_node: ID del nodo que es el mismo que el punto final de la arista."
+
+#~ msgid "left_face: ID of the face on the left of the edge."
+#~ msgstr "left_face: ID de la cara a la izquierda de la arista."
+
+#~ msgid "abs_next_left_edge: Next edge who builds the face on the left."
+#~ msgstr ""
+#~ "abs_next_left_edge: Siguiente arista que construye la cara en la izquierda."
+
+#~ msgid ""
+#~ "next_left_edge: abs_next_left_edge and negative sign if the right face is on"
+#~ " the right of the next left edge."
+#~ msgstr ""
+#~ "next_left_edge: abs_next_left_edge y signo negativo si la cara derecha está "
+#~ "a la derecha de la siguiente arista izquierda."
+
+#~ msgid "right_face: ID of the face on the right of the edge."
+#~ msgstr "right_face: ID de la cara a la derecha de la arista."
+
+#~ msgid "abs_next_right_edge: Next edge who builds the face on the right."
+#~ msgstr ""
+#~ "abs_next_right_edge: Siguiente arista que construye la cara en la derecha."
+
+#~ msgid ""
+#~ "next_right_edge: abs_next_right_edge and negative sign if the left face is "
+#~ "on the right of the next right edge."
+#~ msgstr ""
+#~ "next_right_edge: abs_next_right_edge y signo negativo si la cara izquierda "
+#~ "está a la derecha de la siguiente arista derecha."
+
+#~ msgid "geom: Geometry of the edge."
+#~ msgstr "geom: Geometría de la arista."

--- a/postgis-intro/sources/locale/ja/LC_MESSAGES/topology_topo_types.po
+++ b/postgis-intro/sources/locale/ja/LC_MESSAGES/topology_topo_types.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Introduction to PostGIS 1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-09 10:51+0000\n"
+"POT-Creation-Date: 2025-06-10 18:57+0000\n"
 "PO-Revision-Date: 2025-07-01 01:16+0000\n"
 "Last-Translator: Teramoto Ikuhiro <teramoto.ikuhiro576@naro.go.jp>\n"
-"Language-Team: Japanese <https://weblate.osgeo.org/projects/postgis-workshop/"
-"topology_topo_types/ja/>\n"
+"Language-Team: Japanese <https://weblate.osgeo.org/projects/postgis-workshop/topology_topo_types/ja/>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,431 +18,940 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.4.3\n"
 
-#: ../../en/topology_base_types.rst:4
-msgid "Topology Basic Types"
-msgstr "トポロジ基本タイプ"
-
-#: ../../en/topology_base_types.rst:6
-msgid "Before read this document, at least check one of this documents:"
-msgstr "この文書を読む前に、次の文書の少なくとも一つを確認してください:"
-
-#: ../../en/topology_base_types.rst:8
-msgid "`Introductory workshop: PostGIS Topology Workshop <https://postgis.net/workshops/en/postgis-intro/topology.html>`_."
+#: ../../en/topology_topo_types.rst:4
+msgid "Topology and Geometry Representation"
 msgstr ""
 
-#: ../../en/topology_base_types.rst:10
-msgid "`Manual: PostGIS Topology <https://postgis.net/docs/Topology.html>`_."
-msgstr "`マニュアル: PostGIS トポロジ <https://postgis.net/docs/ja/Topology.html>`_."
-
-#: ../../en/topology_base_types.rst:12
-msgid "`ISO Topology: OGC-SFS Geometries <https://www.gaia-gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
-msgstr ""
-"`ISO Topology: OGC-SFS Geometries <https://www.gaia-gis.it/fossil/"
-"libspatialite/wiki?name=topo-intro>`_."
-
-#: ../../en/topology_base_types.rst:14
-msgid "In this workshop, we will check some fundamentals of topology, its basics and definitions. It is not intended to be a way to use them directly, is to understand it to then be able to use it easily."
-msgstr ""
-"このワークショップでは、トポロジの基本や定義といった基礎的な部分について見て"
-"いきます。直接使うことを目的としたものでなく、理解することでトポロジを簡単に"
-"使えるようになることを目的としています。"
-
-#: ../../en/topology_base_types.rst:18
-msgid "Types"
-msgstr "タイプ"
-
-#: ../../en/topology_base_types.rst:23
-msgid "The basic topology works on three basic types."
-msgstr "基本のトポロジは3種の基本タイプで動作します。"
-
-#: ../../en/topology_base_types.rst:25
-msgid "Node: 2D point, everything starts or ends here"
-msgstr "ノード: 2次元のポイントで、すべてのものがノードから始まりノードで終わります"
-
-#: ../../en/topology_base_types.rst:26
-msgid "Edge: A linestring with direction that start and ends on a node"
-msgstr "エッジ: 有向ラインストリングで、ノードから始まり、ノードで終わります"
-
-#: ../../en/topology_base_types.rst:27
-msgid "Face: Closed set of linestrings, that conforms a polygon"
-msgstr "フェイス: 閉じたラインストリングの集合で、ポリゴンに適合します"
-
-#: ../../en/topology_base_types.rst:29
-msgid "There are some rules for a set of nodes, edges and faces to be valid, check the ISO Topology document, has a very good summary of these conditions, a topology that follows all the rules, is a valid topology."
-msgstr ""
-"ノード、エッジ、フェイスの集合のための規則があります。ISOトポロジドキュメント"
-"を見てください。これらの条件について非常によくまとまっています。全ての規則に"
-"沿うトポロジは妥当なトポロジです。"
-
-#: ../../en/topology_base_types.rst:31
-msgid "Is good to know, until now Postgis will save all this information internally, each type has its own unique ID, and with it we can edit and change them using the available functions, for example with ST_RemEdgeNewFace you can remove an edge and create a new face."
-msgstr ""
-"知るといい話です。PostGIS は全ての情報を内部に格納するまで、"
-"各々のタイプは一意の ID が付きます。この ID "
-"と有効な関数を使って、それらを編集や変更ができます。たとえば "
-"ST_RemEdgeNewFace を使うと、エッジを削除して、新しいフェイスを生成できます。"
-
-#: ../../en/topology_base_types.rst:33
-msgid "But there is still a missing piece, how do we say for example, a face has a specific attribute? Postgis implements several concepts to do this like Layers, TopoGeometry, TopoElement."
-msgstr ""
-"しかし、まだ埋まらないピースがあります。たとえば、"
-"フェイスが特定の属性を持たせるのにどうすればいいのでしょうか? "
-"PostGISはレイヤ、トポジオメトリ、トポエレメントといった概念を実装しています。"
-
-#: ../../en/topology_base_types.rst:36
-msgid "Universal Face"
-msgstr "ユニバーサルフェイス"
-
-#: ../../en/topology_base_types.rst:38
-msgid "It Might be intuitive to think that only the faces constructed by edges exist, there is one exception, all the white space out of all the faces is also a face!"
-msgstr "存在するエッジで構築されるフェイスだけを考えるのが直感的かも知れませんが、全"
-"てのフェイスの外側にある空白もまたフェイスなのです!"
-
-#: ../../en/topology_base_types.rst:40
-msgid "The empty space is called the Universal Face, when a Topology is empty, all the space is the Universal Face, when we add a linestring is an edge of this face, then when we make a polygon it is like make a hole in the face and stealing it to assign it to a face."
-msgstr ""
-"何もない空間はユニバーサルフェイスと呼ばれます。トポロジに何もないときは空間"
-"の全てがユニバーサルフェイスです。ここでラインストリングを追加すると、このフ"
-"ェイスのエッジで、このあと、ポリゴンを作る時には、フェイス内に穴を作り、それ"
-"を奪ってフェイスに割り当てるようなかんじになります。"
-
-#: ../../en/topology_base_types.rst:42
-msgid "This face is infinite and does not have any boundary."
-msgstr "このフェイスは無限大で境界を持ちません。"
-
-#: ../../en/topology_base_types.rst:49
-msgid "The Universal Face has the ID 0."
-msgstr "ユニバーサルフェイスの ID は 0 です。"
-
-#: ../../en/topology_base_types.rst:52
-msgid "Edge interpretation"
-msgstr "エッジの解釈"
-
-#: ../../en/topology_base_types.rst:54
-msgid "To correctly represent a topology and their forms, there are some definitions that are used to construct the tables that store everything, the edge is on the more complex ones."
-msgstr "トポロジとその形状を正しく表現するために、全てを保存するテーブルを構築するた"
-"めの定義が存在します。エッジは、より複雑な定義になっています。"
-
-#: ../../en/topology_base_types.rst:56
-msgid "All the information about edges is stored on the edge_data table, in your custom topology schema, and which information do we need in the edges? basically its nodes and faces information, edge is the primitive who connects both."
-msgstr ""
-"エッジに関する情報はすべて、トポロジスキーマ内の edge_data "
-"テーブルに保存されています。どの情報がエッジに必要でしょうか? "
-"基本的にはノードとフェイスの情報で、エッジは両社を接続するプリミティブです。"
-
-#: ../../en/topology_base_types.rst:58
-msgid "These linestrings are called Edges because they are the edges of the faces."
-msgstr "これらのラインストリングは、フェイスのエッジになるので、エッジと呼ばれます。"
-
-#: ../../en/topology_base_types.rst:61
-msgid "Edge direction, left and right"
-msgstr "エッジ方向、左と右"
-
-#: ../../en/topology_base_types.rst:63
-msgid "Edges in topology has a right defined perspective and view, when we see them must be done in the next way:"
-msgstr "トポロジのエッジには正しく定義された視点と視界とがあります。それらは次のよう"
-"に見えます:"
-
-#: ../../en/topology_base_types.rst:68
-msgid "When we want to see from the edge perspective is always from the end node to the start edge, always looking the edge forward."
-msgstr "エッジから見たいとき、視点は常に終端ノードから始端ノードで、常にエッジ順方向"
-"に見ます。"
-
-#: ../../en/topology_base_types.rst:74
-msgid "The edges have left and right properties, as we see they are defined using the edge perspective, see the linestring from the start node to the end node, there will always be a well defined left and right."
-msgstr ""
-"エッジは左属性と右属性を持ち、エッジの視線を使って定義します。すなわち、ライ"
-"ンストリングの始点ノードから終点ノードを見ます。常に定義づけられた左と右があ"
-"ります。"
-
-#: ../../en/topology_base_types.rst:76
-msgid "So see the edge forward and you always have a left and right side."
-msgstr "エッジの前方向を見ることができ、左と右があることが分かります。"
-
-#: ../../en/topology_base_types.rst:78
-msgid "This helps to relate which faces are on each side of the edge:"
-msgstr "次の図は、どのフェイスがエッジのどちらの側にあるかの関係を見る助けになります"
-"。"
-
-#: ../../en/topology_base_types.rst:83
-msgid "Check the edges on the image, while almost all the edges go from down to up and left to right, there is an orange edge which has the opposite direction, so its sides left and right are swapped in reference to the others, but if you look the edge forward, the right and left are right."
-msgstr ""
-"画像のエッジを確認して、ほとんど全てのエッジが下から上に向かい、左から右に向"
-"かっています。逆方向になるエッジもあります。オレンジ色のエッジです。逆方向の"
-"エッジは、そうでないエッジとは右、左が入れ替わっています。ただ、エッジを順方"
-"向に見ると右左が正しくなります。"
-
-#: ../../en/topology_base_types.rst:85
-msgid "Continue seeing the orange edge, while on its right has a polygon built by the edges, on the left is the Universal Face."
-msgstr "オレンジ色のエッジをそのまま見てください。エッジの右側にそのエッジで作られた"
-"ポリゴンがあり、左側にユニバーサルフェイスがあります。"
-
-#: ../../en/topology_base_types.rst:87
-msgid "When we want to analyze any edge, and we need to see it from the edge perspective, it is always looking the edge in forward, never in backward!"
-msgstr ""
-"あらゆるエッジを解析したい時には、エッジ視点の方向からエッジを見る必要があり"
-"ます。常にエッジの前方を見るようにして、後方を見るようにはしてはいけません!"
-
-#: ../../en/topology_base_types.rst:89
-msgid "Which are all the next edges? Looking forward we go from start node to the end node, all the edges who start or end in the end node of the edge!"
-msgstr ""
-"次のエッジの全てはどれ? 始端ノードから終端ノードへの順方向に見ていくと、エッ"
-"ジの終端ノードを始端または終端とする全てのエッジが当てはまるのです!"
-
-#: ../../en/topology_base_types.rst:92
-msgid "Edge Data"
-msgstr "エッジデータ"
-
-#: ../../en/topology_base_types.rst:94
-msgid "The edge_data table has information related to the edge, from what we know right now we can interpret the next columns:"
-msgstr "edge_data テーブルには、エッジ関連の情報が入っています。これまでで知ったこと"
-"から次に示すカラムを解釈することができます:"
-
-#: ../../en/topology_base_types.rst:96
-msgid "edge_id: Unique ID for the edge"
-msgstr "edge_id: エッジの一意の ID"
-
-#: ../../en/topology_base_types.rst:97
-msgid "start_node: ID for the node who is the same as the start point of the edge"
-msgstr "start_node: エッジの始端と同じノードの ID"
-
-#: ../../en/topology_base_types.rst:98
-msgid "end_node: ID for the node who is the same as the end point of the edge"
-msgstr "end_node: エッジの終端ポイントと同じノードの ID"
-
-#: ../../en/topology_base_types.rst:99
-msgid "left_face: ID of the face on the left of the edge"
-msgstr "left_face: エッジの左側のフェイスの ID"
-
-#: ../../en/topology_base_types.rst:100
-msgid "right_face: ID of the face on the right of the edge"
-msgstr "right_face: エッジの右側のフェイスの ID"
-
-#: ../../en/topology_base_types.rst:101
-msgid "geom: Geometry of the edge"
-msgstr "geom: エッジのジオメトリ"
-
-#: ../../en/topology_base_types.rst:104
-msgid "Abs Next Edge & Next Edge"
-msgstr "Abs Next Edge と Next Edge"
-
-#: ../../en/topology_base_types.rst:106
-msgid "The table edge_data has the columns abs_next_left_edge and abs_next_right_edge, at this moment it gets a little tricky how to interpret it."
-msgstr ""
-"edge_data テーブルには abs_next_left_edge と abs_next_right_edge "
-"というカラムがあります。この場では、少しトリッキーに解釈します。"
-
-#: ../../en/topology_base_types.rst:108
-msgid "Until now we mainly see properties of the edge itself and what has on the sides, the next edge properties are different, do not ask only about the edge itself, it is about which is the next edge who builds the face on the right or left."
-msgstr ""
-"今まで主にエッジ自体のプロパティと、左側や右側にあるものを見ていましたが、"
-"next edge (次のエッジ) プロパティは違います。エッジ自体の情報ではなく、左側化"
-"右側のフェイスを構築する、次のエッジに関する情報が入ります。"
-
-#: ../../en/topology_base_types.rst:110
-msgid "The logic of the right_edge and the left_edge are very similar, so we will look first on the left one deeper and then show the right one."
-msgstr "right_edge と left_edge のロジックはよく似ているので、先に左側を掘り下げて見"
-"て、そのあとで右側を見ます。"
-
-#: ../../en/topology_base_types.rst:112
-msgid "We will be using the next topology as example:"
-msgstr "例として次のトポロジを使います:"
-
-#: ../../en/topology_base_types.rst:119
-msgid "Left"
-msgstr "左側"
-
-#: ../../en/topology_base_types.rst:121
-msgid "Let's pick as an example the Edge 5, this one has on the Left the Face 2, looking forward which is the next edge who builds the Face 2?"
-msgstr ""
-"例として 5番エッジ を取り上げてみましょう。これには、左側に 2番フェイス "
-"があります。順方向に見て、このフェイスを構築する次のエッジはどこでしょう?"
-
-#: ../../en/topology_base_types.rst:123
-msgid "This is the Edge 6."
-msgstr "6番エッジ です。"
-
-#: ../../en/topology_base_types.rst:129
-msgid "Something very important here is the perspective we follow the lines, depending on the Edge direction, is like see the Face clockwise or anticlockwise."
-msgstr "ここで非常に重要なものはラインを追う視点で、これはエッジ方向に依存するもので"
-"、フェイスが時計回りか反時計回りかを見るようなものです。"
-
-#: ../../en/topology_base_types.rst:131
-msgid "With this information we have abs_next_left_edge which will be 6."
-msgstr "この情報で、abs_next_left_edge が 6 になるのが分かります。"
-
-#: ../../en/topology_base_types.rst:133
-msgid "The next_left_edge is almost the same as abs_next_left_edge, except it can be negative which depends on the perspective we see the edge."
-msgstr "next_left_edge は abs_next_left_edge "
-"とほぼ同じですが、エッジを見る視点によっては負数になることがあります。"
-
-#: ../../en/topology_base_types.rst:135
-msgid "If we follow the Edge perspective we will have two directions, the direction of the next edge, and the direction of the perspective on the next edge."
-msgstr "エッジ視点を追いかける場合には、次のエッジの方向と、次のエッジに来た時の視点"
-"での方向との二つの方向があります。"
-
-#: ../../en/topology_base_types.rst:137
-msgid "We will use the next sign in each case:"
-msgstr "次のエッジの符号は次のように使われます:"
-
-#: ../../en/topology_base_types.rst:139
-msgid "Perspective direction and Next edge direction are opposed: \"-\""
-msgstr "視点方向と次のエッジの方向が違う: \"-\""
-
-#: ../../en/topology_base_types.rst:140
-msgid "Perspective direction and Next edge direction are the same: None, keep the value positive"
-msgstr "視点方向と次のエッジの方向が同じ: 符号なし、正の数のまま"
-
-#: ../../en/topology_base_types.rst:142
-msgid "How the Perspective and Edge 6 have the same direction, next_left_edge will be 6."
-msgstr "視点と 6番エッジ は同じ方向なので、next_left_edge は 6 です。"
-
-#: ../../en/topology_base_types.rst:144
-msgid "abs_next_left_edge: 6"
-msgstr "abs_next_left_edge: 6"
-
-#: ../../en/topology_base_types.rst:145
-msgid "next_left_edge: 6"
-msgstr "next_left_edge: 6"
-
-#: ../../en/topology_base_types.rst:148
-msgid "Right"
-msgstr "右側"
-
-#: ../../en/topology_base_types.rst:150
-msgid "The only difference between Left and Right analysis is the perspective, while in Left we use forward, in Right we will see backwards. Be careful, even if we look backwards the definition of Left Face and Right Face are still the same, looking forward! Only changes the perspective to follow."
-msgstr ""
-"左側分析と右側分析との違いは視点だけです。左側解析では順方向ですが、右側解析"
-"では逆方向です。逆方向に見ていたとしても左側フェイスの定義と右側フェイスの定"
-"義は、順方向で見るのと同じことに注意してください。エッジを追う視点だけが変わ"
-"ります。"
-
-#: ../../en/topology_base_types.rst:152
-msgid "The Edge 5 has the Face 0 on its Right, the Universal Face, looking Edge 5 backwards the next edge who builds Face 0 is the Edge 4."
-msgstr ""
-"5番エッジ の右側に 0番フェイス すなわちユニバーサルフェイスがあります。"
-"5番エッジ を逆方向に見ると 0版エッジ を構築する次のエッジは 4番エッジ です。"
-
-#: ../../en/topology_base_types.rst:158
-msgid "Following the perspective of Edge 5 on Edge 4 we can see it goes up, while the Edge 4 goes down, the Perspective direction and the Edge 4 direction are opposed."
-msgstr "4番エッジ 上で 5番エッジ の順方向の視点で見ると、4番エッジ が下に進み、"
-"視点方向と 4番エッジ の方向とが逆になります。"
-
-#: ../../en/topology_base_types.rst:160
-msgid "abs_next_right_edge: 4"
-msgstr "abs_next_right_edge: 4"
-
-#: ../../en/topology_base_types.rst:161
-msgid "nexr_right_edge: -4 (Perspective direction and Edge 4 direction are opposed)"
+#: ../../en/topology_topo_types.rst:6
+msgid ""
+"Before reading this document, please review at least one of these resources:"
 msgstr ""
 
-#: ../../en/topology_base_types.rst:164
-msgid "Isolated Edge Case"
-msgstr "孤立エッジの場合"
-
-#: ../../en/topology_base_types.rst:166
-msgid "There is a case that may be confusing, all the rules above follow in the same way but it is good to take a look."
-msgstr "混乱するかもしれない例です。上の規則全てを同じに適用していますが、見てみると"
-"いいです。"
-
-#: ../../en/topology_base_types.rst:172
-msgid "When we have an Edge that has no connections to other Edges, the first thing we can appreciate is that the Face of the Left is the same as the Right, in this case Face 0, the Universal Face."
+#: ../../en/topology_topo_types.rst:8
+msgid ""
+"`Topology Basic Types <https://postgis.net/workshops/en/postgis-"
+"intro/topology_base_types.html>`_"
 msgstr ""
-"他のエッジと接続しないエッジがある時、最初に私たちが理解できることは、エッジ"
-"は左側のフェイスと右側のフェイスが同じということです。孤立エッジの場合は、"
-"0番フェイス すなわちユニバーサルフェイスです。"
 
-#: ../../en/topology_base_types.rst:174
-msgid "If we follow the past logic, on the Left is the Face 0, which is the next edge who builds Face 0? Actually there is an Edge, and is itself, and it also has a perspective as before:"
+#: ../../en/topology_topo_types.rst:9
+msgid ""
+"`Introductory workshop: PostGIS Topology Workshop "
+"<https://postgis.net/workshops/en/postgis-intro/topology.html>`_"
 msgstr ""
-"過去のロジックに従うと、左側は 0番フェイス となりますが、0番フェイス を構築す"
-"る次のエッジはどれでしょうか？実際は、そのエッジ自体が該当します。前と同じ視"
-"点を持ちます。"
 
-#: ../../en/topology_base_types.rst:180
-msgid "If we check the perspective direction we ends looking the same edge but in opposite direction, this means the Edge 1 and its Next Edge (Edge 1) has opposed directions."
+#: ../../en/topology_topo_types.rst:11
+msgid ""
+"Having a Topology with all its Primitives is useful, but to make it more "
+"practical, we need a way to represent these elements in a table. Similar to "
+"how we have spatial tables, we can have topology tables."
 msgstr ""
-"視点の方向を確認すると、同じエッジを反対方向に見えていることになります。"
-"これは 1番エッジ と次のエッジ (1番エッジ) "
-"とが逆方向になっていることを意味します。"
 
-#: ../../en/topology_base_types.rst:182
-#: ../../en/topology_base_types.rst:194
-msgid "edge_id: 1"
-msgstr "edge_id: 1"
+#: ../../en/topology_topo_types.rst:14
+msgid "Introduction to geometry representation"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:183
-msgid "abs_next_left_edge: 1"
-msgstr "abs_next_left_edge: 1"
+#: ../../en/topology_topo_types.rst:16
+msgid ""
+"If you have followed any example of using Topology to represent geometries "
+"you could remember this, when we populate a Topology table from a Geometry "
+"one we use TopoGeometries instead of Geometries, and in some way each "
+"TopoGeometry is able to represent one or several Primitives contained on the"
+" Topology."
+msgstr ""
 
-#: ../../en/topology_base_types.rst:184
-msgid "next_left_edge: -1 (This will always be negative while we see forward a isolated edge)"
-msgstr "next_left_edge: -1 (孤立エッジを順方向に見ると常に負になります)"
+#: ../../en/topology_topo_types.rst:21
+msgid ""
+"The point is how we reach the actual primitives from the TopoGeometry, how "
+"the data is structured, so first lets see the most global definitions:"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:186
-msgid "For the Next Right Edge is the same, the Next Edge will be it self, the only what it changes is the perspective:"
-msgstr "次の右のエッジは同じですから、次のエッジは、それ自体となります。視点だけ変わ"
-"ります。"
+#: ../../en/topology_topo_types.rst:26
+msgid ""
+"A TopoGeometry can represent a group of Primitives or other TopoGeometries, "
+"in order to create a TopoGeometry you need a Layer."
+msgstr ""
 
-#: ../../en/topology_base_types.rst:192
-msgid "When we look backwards any isolated edge, the perspective will always have the same direction as the Edge so:"
-msgstr "どの孤立エッジでも逆方向に見ると、視点はそのエッジと同じ方向となり、次のよう"
-"になります:"
+#: ../../en/topology_topo_types.rst:28
+msgid ""
+"Layers are the biggest box, they store TopoGeometries which also stores "
+"TopoElements, this last ones represents Primitives or other TopoGeometries."
+msgstr ""
 
-#: ../../en/topology_base_types.rst:195
-msgid "abs_next_right_edge: 1"
-msgstr "abs_next_right_edge: 1"
+#: ../../en/topology_topo_types.rst:31
+msgid "Just to write in two ways:"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:196
-msgid "next_right_edge: -1 (This will always be positive while we see backwar a isolated edge)"
-msgstr "next_right_edge: -1 (孤立エッジを逆方向に見ると、これは常に正の数になります)"
+#: ../../en/topology_topo_types.rst:33
+msgid "Layer contains"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:199
-msgid "Full columns of edge_data"
-msgstr "edge_data の全てのカラム"
+#: ../../en/topology_topo_types.rst:35
+msgid ""
+"TopoGeometries where all of them has the same TopoElement's type, each one "
+"one contains:"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:201
-msgid "We already checked all the columns of the edge_data table:"
-msgstr "edge_dataテーブル の全てのカラムをすでに確認しています:"
+#: ../../en/topology_topo_types.rst:37
+msgid "TopoElements where each one can represent a:"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:203
-msgid "edge_id: Unique ID for the edge."
-msgstr "edge_id: エッジの一意の ID。"
+#: ../../en/topology_topo_types.rst:39
+msgid "TopoGeometry of other Layer"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:204
-msgid "start_node: ID for the node which is the same as the start point of the edge."
-msgstr "start_node: エッジの始端と同じノードの ID。"
+#: ../../en/topology_topo_types.rst:40
+msgid "Geometry Collection"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:205
-msgid "end_node: ID for the node which is the same as the end point of the edge."
-msgstr "end_node: エッジの終端と同じノードの ID。"
+#: ../../en/topology_topo_types.rst:41
+msgid "Primitive from the Topology"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:206
-msgid "left_face: ID of the face on the left of the edge."
-msgstr "left_face: エッジの左側のフェイスの ID。"
+#: ../../en/topology_topo_types.rst:43 ../../en/topology_topo_types.rst:62
+msgid "Nodes"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:207
-msgid "abs_next_left_edge: Next edge who builds the face on the left."
-msgstr "abs_next_left_edge: 左側のフェイスを構築する次のエッジ。"
+#: ../../en/topology_topo_types.rst:44 ../../en/topology_topo_types.rst:63
+msgid "Edges"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:208
-msgid "next_left_edge: abs_next_left_edge and negative sign if the right face is on the right of the next left edge."
-msgstr "next_left_edge: abs_next_left_edge "
-"と、右側のフェイスが次の左側のエッジの右側にあるならマイナス符号。"
+#: ../../en/topology_topo_types.rst:45 ../../en/topology_topo_types.rst:64
+msgid "Faces"
+msgstr ""
 
-#: ../../en/topology_base_types.rst:209
-msgid "right_face: ID of the face on the right of the edge."
-msgstr "right_face: 右側のフェイスの ID。"
+#: ../../en/topology_topo_types.rst:47
+msgid ""
+"TopoGeometries are exposed as keys, they has a unique key inside the Layer, "
+"but also stores its Layer Key, this allows Postgis to store it in an "
+"arbitrary column and always be able to find its TopoElements, and with them "
+"what they represent."
+msgstr ""
 
-#: ../../en/topology_base_types.rst:210
-msgid "abs_next_right_edge: Next edge who builds the face on the right."
-msgstr "abs_next_right_edge: 右側のエッジを構築する次のエッジ。"
+#: ../../en/topology_topo_types.rst:49
+msgid ""
+"You need a Layer where a TopoGeometry will be constructed, and after that "
+"you don't need to remember to which Layer it belongs."
+msgstr ""
 
-#: ../../en/topology_base_types.rst:211
-msgid "next_right_edge: abs_next_right_edge and negative sign if the left face is on the right of the next right edge."
-msgstr "next_right_edge: abs_next_right_edge "
-"と、左側のフェイスが次の右側のエッジの右側にあるならマイナス符号。"
+#: ../../en/topology_topo_types.rst:51
+msgid ""
+"This concept is the one used for the user, from this point we will explain "
+"deep and technical details."
+msgstr ""
 
-#: ../../en/topology_base_types.rst:212
-msgid "geom: Geometry of the edge."
-msgstr "geom: エッジのジオメトリ。"
+#: ../../en/topology_topo_types.rst:53
+msgid ""
+"As a side note, Postgis Topology has internally some tricks when its about "
+"keys, helps to optimize a lot of parts but at the same time there is a lot "
+"of reduntant information, do not be supreised if you find the same "
+"information in two or more places."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:56
+msgid "Features"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:58
+msgid ""
+"TopoElements can represent a TopoGeometry and a Primitive, think in a "
+"TopoGeometry, if store them in a TopoElement, they still contain other "
+"TopoElements, if we follow its path we will always ends in Primitives of the"
+" Topology."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:60
+msgid ""
+"Features will represent which type the set of geometries will be, is not "
+"important if you use TopoGeometries or Primitives, in the end a Layer can "
+"contain directly or indirectly any of this sets:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:65
+msgid "Geometry Collections"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:67
+msgid ""
+"The numbers are important, in any function which requests the Feature Type, "
+"you can specify it using the number or the name as string."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:70
+msgid "Hierarchical Layers, Childs and Parents"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:72
+msgid ""
+"I would like to introduce this concept later, but to explain better and "
+"deeper the concept you will find this is needed."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:77
+msgid ""
+"The first aspect on the image is a table that is constructed using "
+"Primitives, Layer 1 will have TopoGeometries where its TopoElements only "
+"make a reference to Primitives of the topology."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:79
+msgid "We define the relationship between Layer 1 and Primitives as:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:81
+msgid "Layer 1 is Parent of the Primitives"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:82
+msgid "Primitives are Childs of the Layer 1"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:84
+msgid ""
+"The relation between Parent and Child is about the size, Childs are small, "
+"when we have a group of them we build a Parent, a bigger group."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:86
+msgid ""
+"Layer 2 has as childs the Layer 1, this implies each TopoGeometry from this "
+"layer, can make a reference to one or multiple TopoGeometries of the Layer "
+"1."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:88
+msgid ""
+"This also means you can't pick half of a TopoGeometry from Layer 1, pick "
+"half of it means you need a reference to one of the TopoElements of a "
+"TopoGeometry, which in this case belongs to the Primitives (its Child), if "
+"you really need that then build Layer 2 using Layer 1 childs (Primitives)."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:90
+msgid ""
+"Each Layer can only have one Child Layer, this means, the Child and Parent "
+"share the same Topology schema."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:92
+msgid ""
+"You will notice some aspects of Hierarchy could change to maybe support "
+"something like half TopoGeometry or mixing Layers, but right now is not "
+"implemented."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:95
+msgid "Layers"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:97
+msgid ""
+"To store TopoGeometries we need a Layer, due to this when we create a "
+"TopoGeometrie's Column, we also create a Layer, this is why we use a special"
+" function to create a column for this."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:99
+msgid ""
+"`Crete TopoGeometry Column "
+"<https://postgis.net/docs/AddTopoGeometryColumn.html>`_"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:101
+msgid ""
+"Layers and TopoGeometry Columns have a special relationship, they are "
+"linked, but they are not the same."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:103
+msgid ""
+"Layers have a lot of information that we must provide to know which type of "
+"Layer we want."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:105
+msgid ""
+"Layers have a unique identifier in each topology, this identifier is called "
+"layer_id."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:107
+msgid "Layers Key: Composed Key with [topology_id, layer_id]"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:108
+msgid ""
+"Table route: Schema name, table name and column name to know where it is "
+"linked."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:109
+msgid "Feature Type: Feature type the layer will contain."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:110
+msgid ""
+"Level: This value starts at 0, in the case we construct this layer using "
+"another layer, it will add 1, so we know how many layers we are from the "
+"Primitives, if the value is 0 means the Layer is constructed using "
+"Primitives instead of TopoGeometries."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:111
+msgid ""
+"child_id: In case the layer is built not using Primitives and using another "
+"Layer as base, we need the Layer Identifier (layer_id) of this layer, we do "
+"not need topology_id because we already know it from the parent."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:114
+msgid "Relation's Table"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:116
+msgid ""
+"Finally, the section you may be looking at, how Postgis Topology goes from a"
+" TopoGeometry to what they contain."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:118
+msgid ""
+"The Relation's table function is be the bridge between the Parent and "
+"Childs."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:120
+msgid "This table can be found in: ``my_topology.relation``."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:123
+msgid "Keys and Identifiers we know now"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:125
+msgid ""
+"I'll use the word \"Identifier\" as a unique key in a particular context. "
+"For example each layer has a number as an identifier (layer_id), it is "
+"unique in its topology context, but is not enough to find a layer in a "
+"database."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:127
+msgid ""
+"While Identifiers will work in a context, the Key will be the full way to "
+"address an element, for example the key for any layer are two values "
+"[topology_id, layer_id]."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:133
+msgid "The image is a good summary of how the keys for each are composed."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:136
+msgid "Implicit identifiers on Keys"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:138
+msgid ""
+"Postgis uses at some extent an implicit logic when working with Layers and "
+"TopoGeometries, this is because they have a context where you don't need to "
+"store the full Key to know it."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:140
+msgid "To show an example:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:142
+msgid "TopoGeometry is composed by:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:144
+msgid "topology_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:145
+msgid "layer_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:146
+msgid "topogeometry_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:148
+msgid ""
+"As we said before, the relation's table is stored inside the topology "
+"schema. This table will contain the relation of the TopoGeometry with the "
+"TopoElements, to make a reference in this context, do we need the "
+"topology_id?"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:150
+msgid ""
+"We can skip it! While we are out of the topology schema we need the id to "
+"find it, but while we are inside it we can look at the schema name, and find"
+" its id on the table ``topology.topology``, which has all topologies ids and"
+" names."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:153
+msgid "TopoGeometry"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:155
+msgid "TopoGeometry is a composite key with the next elements:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:157
+msgid "topology_id: topology_id of TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:158
+msgid "layer_id: layer_id of the TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:159
+msgid "id: topogeometry_id of the TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:160
+msgid "type: Feature type as number"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:163
+msgid "Basic Relation's table structure"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:165
+msgid ""
+"Each schema topology can have its own relation's table, it will be created "
+"when you create your first TopoGeometry, the table is stored inside the "
+"topology as ``custom_topology.relation``."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:167
+msgid ""
+"Each row of the table is called a \"Component\", like a component of the "
+"relations."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:169
+msgid ""
+"The component saves pairs of two things, a TopoGeometry Key and a "
+"TopoElement, remember that each TopoElement can only represent one Primitive"
+" or TopoGeometry, so for a TopoGeometry be able to represent several of them"
+" the tables stores multiple rows with the same TopoGeometry Key and "
+"different TopoElements, this way only filtering in the table we can get all "
+"the TopoElements for any TopoGeometry."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:176
+msgid "Find Components of a TopoGeometry"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:178
+msgid ""
+"To find which components belong to a TopoGeometry is a little tricky, "
+"because here will work the implicit Keys."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:180
+msgid "A component has the next elements:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:182
+msgid "TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:184
+msgid "topogeom_id: topogeometry_id from TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:185
+msgid "layer_id: layer_id from TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:187
+msgid "TopoElement"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:189
+msgid "element_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:190
+msgid "element_type"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:192
+msgid ""
+"We can notice the TopoGeometry Key is incomplete, this is because the "
+"relation's table already belongs to a topology, so there is no need to store"
+" the topology identifier again."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:194
+msgid ""
+"To reach from a TopoGeometry to a Component we need to look the "
+"TopoGeometry.topology_id and search on ``topology.topology.id`` and retrieve"
+" the Topology Name, with it we can found the relation's table in their "
+"respective schema."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:201
+msgid "Reading TopoElements"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:203
+msgid ""
+"The last part to decompose TopoGeometry is to be able to interpret the "
+"TopoElements which is more complex than other keys, because its meaning can "
+"change based on the Layer it is saved."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:205
+msgid ""
+"As we talked, a Layer can have as Childs two options, Primitives or "
+"TopoGeometries."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:207
+msgid ""
+"The first we need to know is which Childs it is using, for this we need to "
+"look on ``topology.layer.id`` using the ``TopoGeometry Key.layer_id`` and "
+"get ```topology.layer.child_id```."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:209
+msgid "So the cases depends on child_id:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:211
+msgid "If is NULL:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:213
+msgid "element_id: Primitive Identifier"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:214
+msgid ""
+"element_type: Feature number, look on the Features to know to which "
+"primitive table too look on."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:216
+msgid "If is not NULL:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:218
+msgid "element_id: topogeometry_id from a TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:219
+msgid "element_type: layer_id from a TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:221
+msgid ""
+"The first case is trivial, just look at their respective Primitive table and"
+" use the identifier to know which primitive is."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:223
+msgid ""
+"While the second case the TopoElement is used to build a new TopoGeometry "
+"Key, the topology_id is implicit as we talked, so the Key is complete, to "
+"find the new elements look again on the relation's table but using the new "
+"keys."
+msgstr ""
+
+#~ msgid "Topology Basic Types"
+#~ msgstr "トポロジ基本タイプ"
+
+#~ msgid ""
+#~ "`ISO Topology: OGC-SFS Geometries <https://www.gaia-"
+#~ "gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+#~ msgstr ""
+#~ "`ISO Topology: OGC-SFS Geometries <https://www.gaia-"
+#~ "gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+
+#~ msgid ""
+#~ "In this workshop, we will check some fundamentals of topology, its basics "
+#~ "and definitions. It is not intended to be a way to use them directly, is to "
+#~ "understand it to then be able to use it easily."
+#~ msgstr ""
+#~ "このワークショップでは、トポロジの基本や定義といった基礎的な部分について見ていきます。直接使うことを目的としたものでなく、理解することでトポロジを簡単に使えるようになることを目的としています。"
+
+#~ msgid "Types"
+#~ msgstr "タイプ"
+
+#~ msgid "The basic topology works on three basic types."
+#~ msgstr "基本のトポロジは3種の基本タイプで動作します。"
+
+#~ msgid "Node: 2D point, everything starts or ends here"
+#~ msgstr "ノード: 2次元のポイントで、すべてのものがノードから始まりノードで終わります"
+
+#~ msgid "Edge: A linestring with direction that start and ends on a node"
+#~ msgstr "エッジ: 有向ラインストリングで、ノードから始まり、ノードで終わります"
+
+#~ msgid "Face: Closed set of linestrings, that conforms a polygon"
+#~ msgstr "フェイス: 閉じたラインストリングの集合で、ポリゴンに適合します"
+
+#~ msgid ""
+#~ "There are some rules for a set of nodes, edges and faces to be valid, check "
+#~ "the ISO Topology document, has a very good summary of these conditions, a "
+#~ "topology that follows all the rules, is a valid topology."
+#~ msgstr ""
+#~ "ノード、エッジ、フェイスの集合のための規則があります。ISOトポロジドキュメントを見てください。これらの条件について非常によくまとまっています。全ての規則に沿うトポロジは妥当なトポロジです。"
+
+#~ msgid ""
+#~ "Is good to know, until now Postgis will save all this information "
+#~ "internally, each type has its own unique ID, and with it we can edit and "
+#~ "change them using the available functions, for example with "
+#~ "ST_RemEdgeNewFace you can remove an edge and create a new face."
+#~ msgstr ""
+#~ "知るといい話です。PostGIS は全ての情報を内部に格納するまで、各々のタイプは一意の ID が付きます。この ID "
+#~ "と有効な関数を使って、それらを編集や変更ができます。たとえば ST_RemEdgeNewFace "
+#~ "を使うと、エッジを削除して、新しいフェイスを生成できます。"
+
+#~ msgid ""
+#~ "But there is still a missing piece, how do we say for example, a face has a "
+#~ "specific attribute? Postgis implements several concepts to do this like "
+#~ "Layers, TopoGeometry, TopoElement."
+#~ msgstr ""
+#~ "しかし、まだ埋まらないピースがあります。たとえば、フェイスが特定の属性を持たせるのにどうすればいいのでしょうか? "
+#~ "PostGISはレイヤ、トポジオメトリ、トポエレメントといった概念を実装しています。"
+
+#~ msgid "Universal Face"
+#~ msgstr "ユニバーサルフェイス"
+
+#~ msgid ""
+#~ "It Might be intuitive to think that only the faces constructed by edges "
+#~ "exist, there is one exception, all the white space out of all the faces is "
+#~ "also a face!"
+#~ msgstr "存在するエッジで構築されるフェイスだけを考えるのが直感的かも知れませんが、全てのフェイスの外側にある空白もまたフェイスなのです!"
+
+#~ msgid ""
+#~ "The empty space is called the Universal Face, when a Topology is empty, all "
+#~ "the space is the Universal Face, when we add a linestring is an edge of this"
+#~ " face, then when we make a polygon it is like make a hole in the face and "
+#~ "stealing it to assign it to a face."
+#~ msgstr ""
+#~ "何もない空間はユニバーサルフェイスと呼ばれます。トポロジに何もないときは空間の全てがユニバーサルフェイスです。ここでラインストリングを追加すると、このフェイスのエッジで、このあと、ポリゴンを作る時には、フェイス内に穴を作り、それを奪ってフェイスに割り当てるようなかんじになります。"
+
+#~ msgid "This face is infinite and does not have any boundary."
+#~ msgstr "このフェイスは無限大で境界を持ちません。"
+
+#~ msgid "The Universal Face has the ID 0."
+#~ msgstr "ユニバーサルフェイスの ID は 0 です。"
+
+#~ msgid "Edge interpretation"
+#~ msgstr "エッジの解釈"
+
+#~ msgid ""
+#~ "To correctly represent a topology and their forms, there are some "
+#~ "definitions that are used to construct the tables that store everything, the"
+#~ " edge is on the more complex ones."
+#~ msgstr "トポロジとその形状を正しく表現するために、全てを保存するテーブルを構築するための定義が存在します。エッジは、より複雑な定義になっています。"
+
+#~ msgid ""
+#~ "All the information about edges is stored on the edge_data table, in your "
+#~ "custom topology schema, and which information do we need in the edges? "
+#~ "basically its nodes and faces information, edge is the primitive who "
+#~ "connects both."
+#~ msgstr ""
+#~ "エッジに関する情報はすべて、トポロジスキーマ内の edge_data テーブルに保存されています。どの情報がエッジに必要でしょうか? "
+#~ "基本的にはノードとフェイスの情報で、エッジは両社を接続するプリミティブです。"
+
+#~ msgid ""
+#~ "These linestrings are called Edges because they are the edges of the faces."
+#~ msgstr "これらのラインストリングは、フェイスのエッジになるので、エッジと呼ばれます。"
+
+#~ msgid "Edge direction, left and right"
+#~ msgstr "エッジ方向、左と右"
+
+#~ msgid ""
+#~ "Edges in topology has a right defined perspective and view, when we see them"
+#~ " must be done in the next way:"
+#~ msgstr "トポロジのエッジには正しく定義された視点と視界とがあります。それらは次のように見えます:"
+
+#~ msgid ""
+#~ "When we want to see from the edge perspective is always from the end node to"
+#~ " the start edge, always looking the edge forward."
+#~ msgstr "エッジから見たいとき、視点は常に終端ノードから始端ノードで、常にエッジ順方向に見ます。"
+
+#~ msgid ""
+#~ "The edges have left and right properties, as we see they are defined using "
+#~ "the edge perspective, see the linestring from the start node to the end "
+#~ "node, there will always be a well defined left and right."
+#~ msgstr ""
+#~ "エッジは左属性と右属性を持ち、エッジの視線を使って定義します。すなわち、ラインストリングの始点ノードから終点ノードを見ます。常に定義づけられた左と右があります。"
+
+#~ msgid "So see the edge forward and you always have a left and right side."
+#~ msgstr "エッジの前方向を見ることができ、左と右があることが分かります。"
+
+#~ msgid "This helps to relate which faces are on each side of the edge:"
+#~ msgstr "次の図は、どのフェイスがエッジのどちらの側にあるかの関係を見る助けになります。"
+
+#~ msgid ""
+#~ "Check the edges on the image, while almost all the edges go from down to up "
+#~ "and left to right, there is an orange edge which has the opposite direction,"
+#~ " so its sides left and right are swapped in reference to the others, but if "
+#~ "you look the edge forward, the right and left are right."
+#~ msgstr ""
+#~ "画像のエッジを確認して、ほとんど全てのエッジが下から上に向かい、左から右に向かっています。逆方向になるエッジもあります。オレンジ色のエッジです。逆方向のエッジは、そうでないエッジとは右、左が入れ替わっています。ただ、エッジを順方向に見ると右左が正しくなります。"
+
+#~ msgid ""
+#~ "Continue seeing the orange edge, while on its right has a polygon built by "
+#~ "the edges, on the left is the Universal Face."
+#~ msgstr "オレンジ色のエッジをそのまま見てください。エッジの右側にそのエッジで作られたポリゴンがあり、左側にユニバーサルフェイスがあります。"
+
+#~ msgid ""
+#~ "When we want to analyze any edge, and we need to see it from the edge "
+#~ "perspective, it is always looking the edge in forward, never in backward!"
+#~ msgstr ""
+#~ "あらゆるエッジを解析したい時には、エッジ視点の方向からエッジを見る必要があります。常にエッジの前方を見るようにして、後方を見るようにはしてはいけません!"
+
+#~ msgid ""
+#~ "Which are all the next edges? Looking forward we go from start node to the "
+#~ "end node, all the edges who start or end in the end node of the edge!"
+#~ msgstr ""
+#~ "次のエッジの全てはどれ? 始端ノードから終端ノードへの順方向に見ていくと、エッジの終端ノードを始端または終端とする全てのエッジが当てはまるのです!"
+
+#~ msgid "Edge Data"
+#~ msgstr "エッジデータ"
+
+#~ msgid ""
+#~ "The edge_data table has information related to the edge, from what we know "
+#~ "right now we can interpret the next columns:"
+#~ msgstr "edge_data テーブルには、エッジ関連の情報が入っています。これまでで知ったことから次に示すカラムを解釈することができます:"
+
+#~ msgid "edge_id: Unique ID for the edge"
+#~ msgstr "edge_id: エッジの一意の ID"
+
+#~ msgid ""
+#~ "start_node: ID for the node who is the same as the start point of the edge"
+#~ msgstr "start_node: エッジの始端と同じノードの ID"
+
+#~ msgid "end_node: ID for the node who is the same as the end point of the edge"
+#~ msgstr "end_node: エッジの終端ポイントと同じノードの ID"
+
+#~ msgid "left_face: ID of the face on the left of the edge"
+#~ msgstr "left_face: エッジの左側のフェイスの ID"
+
+#~ msgid "right_face: ID of the face on the right of the edge"
+#~ msgstr "right_face: エッジの右側のフェイスの ID"
+
+#~ msgid "Abs Next Edge & Next Edge"
+#~ msgstr "Abs Next Edge と Next Edge"
+
+#~ msgid ""
+#~ "The table edge_data has the columns abs_next_left_edge and "
+#~ "abs_next_right_edge, at this moment it gets a little tricky how to interpret"
+#~ " it."
+#~ msgstr ""
+#~ "edge_data テーブルには abs_next_left_edge と abs_next_right_edge "
+#~ "というカラムがあります。この場では、少しトリッキーに解釈します。"
+
+#~ msgid ""
+#~ "Until now we mainly see properties of the edge itself and what has on the "
+#~ "sides, the next edge properties are different, do not ask only about the "
+#~ "edge itself, it is about which is the next edge who builds the face on the "
+#~ "right or left."
+#~ msgstr ""
+#~ "今まで主にエッジ自体のプロパティと、左側や右側にあるものを見ていましたが、next edge (次のエッジ) "
+#~ "プロパティは違います。エッジ自体の情報ではなく、左側化右側のフェイスを構築する、次のエッジに関する情報が入ります。"
+
+#~ msgid ""
+#~ "The logic of the right_edge and the left_edge are very similar, so we will "
+#~ "look first on the left one deeper and then show the right one."
+#~ msgstr "right_edge と left_edge のロジックはよく似ているので、先に左側を掘り下げて見て、そのあとで右側を見ます。"
+
+#~ msgid "We will be using the next topology as example:"
+#~ msgstr "例として次のトポロジを使います:"
+
+#~ msgid "Left"
+#~ msgstr "左側"
+
+#~ msgid ""
+#~ "Let's pick as an example the Edge 5, this one has on the Left the Face 2, "
+#~ "looking forward which is the next edge who builds the Face 2?"
+#~ msgstr ""
+#~ "例として 5番エッジ を取り上げてみましょう。これには、左側に 2番フェイス があります。順方向に見て、このフェイスを構築する次のエッジはどこでしょう?"
+
+#~ msgid "This is the Edge 6."
+#~ msgstr "6番エッジ です。"
+
+#~ msgid ""
+#~ "Something very important here is the perspective we follow the lines, "
+#~ "depending on the Edge direction, is like see the Face clockwise or "
+#~ "anticlockwise."
+#~ msgstr "ここで非常に重要なものはラインを追う視点で、これはエッジ方向に依存するもので、フェイスが時計回りか反時計回りかを見るようなものです。"
+
+#~ msgid "With this information we have abs_next_left_edge which will be 6."
+#~ msgstr "この情報で、abs_next_left_edge が 6 になるのが分かります。"
+
+#~ msgid ""
+#~ "The next_left_edge is almost the same as abs_next_left_edge, except it can "
+#~ "be negative which depends on the perspective we see the edge."
+#~ msgstr ""
+#~ "next_left_edge は abs_next_left_edge とほぼ同じですが、エッジを見る視点によっては負数になることがあります。"
+
+#~ msgid ""
+#~ "If we follow the Edge perspective we will have two directions, the direction"
+#~ " of the next edge, and the direction of the perspective on the next edge."
+#~ msgstr "エッジ視点を追いかける場合には、次のエッジの方向と、次のエッジに来た時の視点での方向との二つの方向があります。"
+
+#~ msgid "We will use the next sign in each case:"
+#~ msgstr "次のエッジの符号は次のように使われます:"
+
+#~ msgid "Perspective direction and Next edge direction are opposed: \"-\""
+#~ msgstr "視点方向と次のエッジの方向が違う: \"-\""
+
+#~ msgid ""
+#~ "Perspective direction and Next edge direction are the same: None, keep the "
+#~ "value positive"
+#~ msgstr "視点方向と次のエッジの方向が同じ: 符号なし、正の数のまま"
+
+#~ msgid ""
+#~ "How the Perspective and Edge 6 have the same direction, next_left_edge will "
+#~ "be 6."
+#~ msgstr "視点と 6番エッジ は同じ方向なので、next_left_edge は 6 です。"
+
+#~ msgid "abs_next_left_edge: 6"
+#~ msgstr "abs_next_left_edge: 6"
+
+#~ msgid "next_left_edge: 6"
+#~ msgstr "next_left_edge: 6"
+
+#~ msgid "Right"
+#~ msgstr "右側"
+
+#~ msgid ""
+#~ "The only difference between Left and Right analysis is the perspective, "
+#~ "while in Left we use forward, in Right we will see backwards. Be careful, "
+#~ "even if we look backwards the definition of Left Face and Right Face are "
+#~ "still the same, looking forward! Only changes the perspective to follow."
+#~ msgstr ""
+#~ "左側分析と右側分析との違いは視点だけです。左側解析では順方向ですが、右側解析では逆方向です。逆方向に見ていたとしても左側フェイスの定義と右側フェイスの定義は、順方向で見るのと同じことに注意してください。エッジを追う視点だけが変わります。"
+
+#~ msgid ""
+#~ "The Edge 5 has the Face 0 on its Right, the Universal Face, looking Edge 5 "
+#~ "backwards the next edge who builds Face 0 is the Edge 4."
+#~ msgstr ""
+#~ "5番エッジ の右側に 0番フェイス すなわちユニバーサルフェイスがあります。5番エッジ を逆方向に見ると 0版エッジ を構築する次のエッジは 4番エッジ"
+#~ " です。"
+
+#~ msgid ""
+#~ "Following the perspective of Edge 5 on Edge 4 we can see it goes up, while "
+#~ "the Edge 4 goes down, the Perspective direction and the Edge 4 direction are"
+#~ " opposed."
+#~ msgstr "4番エッジ 上で 5番エッジ の順方向の視点で見ると、4番エッジ が下に進み、視点方向と 4番エッジ の方向とが逆になります。"
+
+#~ msgid "abs_next_right_edge: 4"
+#~ msgstr "abs_next_right_edge: 4"
+
+#~ msgid "Isolated Edge Case"
+#~ msgstr "孤立エッジの場合"
+
+#~ msgid ""
+#~ "There is a case that may be confusing, all the rules above follow in the "
+#~ "same way but it is good to take a look."
+#~ msgstr "混乱するかもしれない例です。上の規則全てを同じに適用していますが、見てみるといいです。"
+
+#~ msgid ""
+#~ "When we have an Edge that has no connections to other Edges, the first thing"
+#~ " we can appreciate is that the Face of the Left is the same as the Right, in"
+#~ " this case Face 0, the Universal Face."
+#~ msgstr ""
+#~ "他のエッジと接続しないエッジがある時、最初に私たちが理解できることは、エッジは左側のフェイスと右側のフェイスが同じということです。孤立エッジの場合は、0番フェイス"
+#~ " すなわちユニバーサルフェイスです。"
+
+#~ msgid ""
+#~ "If we follow the past logic, on the Left is the Face 0, which is the next "
+#~ "edge who builds Face 0? Actually there is an Edge, and is itself, and it "
+#~ "also has a perspective as before:"
+#~ msgstr ""
+#~ "過去のロジックに従うと、左側は 0番フェイス となりますが、0番フェイス "
+#~ "を構築する次のエッジはどれでしょうか？実際は、そのエッジ自体が該当します。前と同じ視点を持ちます。"
+
+#~ msgid ""
+#~ "If we check the perspective direction we ends looking the same edge but in "
+#~ "opposite direction, this means the Edge 1 and its Next Edge (Edge 1) has "
+#~ "opposed directions."
+#~ msgstr ""
+#~ "視点の方向を確認すると、同じエッジを反対方向に見えていることになります。これは 1番エッジ と次のエッジ (1番エッジ) "
+#~ "とが逆方向になっていることを意味します。"
+
+#~ msgid "edge_id: 1"
+#~ msgstr "edge_id: 1"
+
+#~ msgid "abs_next_left_edge: 1"
+#~ msgstr "abs_next_left_edge: 1"
+
+#~ msgid ""
+#~ "next_left_edge: -1 (This will always be negative while we see forward a "
+#~ "isolated edge)"
+#~ msgstr "next_left_edge: -1 (孤立エッジを順方向に見ると常に負になります)"
+
+#~ msgid ""
+#~ "For the Next Right Edge is the same, the Next Edge will be it self, the only"
+#~ " what it changes is the perspective:"
+#~ msgstr "次の右のエッジは同じですから、次のエッジは、それ自体となります。視点だけ変わります。"
+
+#~ msgid ""
+#~ "When we look backwards any isolated edge, the perspective will always have "
+#~ "the same direction as the Edge so:"
+#~ msgstr "どの孤立エッジでも逆方向に見ると、視点はそのエッジと同じ方向となり、次のようになります:"
+
+#~ msgid "abs_next_right_edge: 1"
+#~ msgstr "abs_next_right_edge: 1"
+
+#~ msgid ""
+#~ "next_right_edge: -1 (This will always be positive while we see backwar a "
+#~ "isolated edge)"
+#~ msgstr "next_right_edge: -1 (孤立エッジを逆方向に見ると、これは常に正の数になります)"
+
+#~ msgid "Full columns of edge_data"
+#~ msgstr "edge_data の全てのカラム"
+
+#~ msgid "We already checked all the columns of the edge_data table:"
+#~ msgstr "edge_dataテーブル の全てのカラムをすでに確認しています:"
+
+#~ msgid "edge_id: Unique ID for the edge."
+#~ msgstr "edge_id: エッジの一意の ID。"
+
+#~ msgid ""
+#~ "start_node: ID for the node which is the same as the start point of the "
+#~ "edge."
+#~ msgstr "start_node: エッジの始端と同じノードの ID。"
+
+#~ msgid ""
+#~ "end_node: ID for the node which is the same as the end point of the edge."
+#~ msgstr "end_node: エッジの終端と同じノードの ID。"
+
+#~ msgid "left_face: ID of the face on the left of the edge."
+#~ msgstr "left_face: エッジの左側のフェイスの ID。"
+
+#~ msgid "abs_next_left_edge: Next edge who builds the face on the left."
+#~ msgstr "abs_next_left_edge: 左側のフェイスを構築する次のエッジ。"
+
+#~ msgid ""
+#~ "next_left_edge: abs_next_left_edge and negative sign if the right face is on"
+#~ " the right of the next left edge."
+#~ msgstr "next_left_edge: abs_next_left_edge と、右側のフェイスが次の左側のエッジの右側にあるならマイナス符号。"
+
+#~ msgid "right_face: ID of the face on the right of the edge."
+#~ msgstr "right_face: 右側のフェイスの ID。"
+
+#~ msgid "abs_next_right_edge: Next edge who builds the face on the right."
+#~ msgstr "abs_next_right_edge: 右側のエッジを構築する次のエッジ。"
+
+#~ msgid ""
+#~ "next_right_edge: abs_next_right_edge and negative sign if the left face is "
+#~ "on the right of the next right edge."
+#~ msgstr ""
+#~ "next_right_edge: abs_next_right_edge と、左側のフェイスが次の右側のエッジの右側にあるならマイナス符号。"
+
+#~ msgid "geom: Geometry of the edge."
+#~ msgstr "geom: エッジのジオメトリ。"

--- a/postgis-intro/sources/locale/sv/LC_MESSAGES/topology_topo_types.po
+++ b/postgis-intro/sources/locale/sv/LC_MESSAGES/topology_topo_types.po
@@ -7,11 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Introduction to PostGIS 1.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-09 10:51+0000\n"
+"POT-Creation-Date: 2025-06-10 18:57+0000\n"
 "PO-Revision-Date: 2025-06-10 20:47+0000\n"
 "Last-Translator: Daniel Nylander <daniel@danielnylander.se>\n"
-"Language-Team: Swedish <https://weblate.osgeo.org/projects/postgis-workshop/"
-"topology_topo_types/sv/>\n"
+"Language-Team: Swedish <https://weblate.osgeo.org/projects/postgis-workshop/topology_topo_types/sv/>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,468 +18,1021 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.4.3\n"
 
-#: ../../en/topology_base_types.rst:4
-msgid "Topology Basic Types"
-msgstr "Grundläggande topologityper"
-
-#: ../../en/topology_base_types.rst:6
-msgid "Before read this document, at least check one of this documents:"
+#: ../../en/topology_topo_types.rst:4
+msgid "Topology and Geometry Representation"
 msgstr ""
-"Innan du läser detta dokument ska du åtminstone titta på ett av dessa "
-"dokument:"
 
-#: ../../en/topology_base_types.rst:8
-msgid "`Introductory workshop: PostGIS Topology Workshop <https://postgis.net/workshops/en/postgis-intro/topology.html>`_."
+#: ../../en/topology_topo_types.rst:6
+msgid ""
+"Before reading this document, please review at least one of these resources:"
 msgstr ""
-"`Introduktiv workshop: PostGIS Topology Workshop <https://postgis.net/"
-"workshops/en/postgis-intro/topology.html>`_."
 
-#: ../../en/topology_base_types.rst:10
-msgid "`Manual: PostGIS Topology <https://postgis.net/docs/Topology.html>`_."
-msgstr "`Handbok: PostGIS-topologi <https://postgis.net/docs/Topology.html>`_."
-
-#: ../../en/topology_base_types.rst:12
-msgid "`ISO Topology: OGC-SFS Geometries <https://www.gaia-gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+#: ../../en/topology_topo_types.rst:8
+msgid ""
+"`Topology Basic Types <https://postgis.net/workshops/en/postgis-"
+"intro/topology_base_types.html>`_"
 msgstr ""
-"`ISO Topology: OGC-SFS Geometries <https://www.gaia-gis.it/fossil/"
-"libspatialite/wiki?name=topo-intro>`_."
 
-#: ../../en/topology_base_types.rst:14
-msgid "In this workshop, we will check some fundamentals of topology, its basics and definitions. It is not intended to be a way to use them directly, is to understand it to then be able to use it easily."
+#: ../../en/topology_topo_types.rst:9
+msgid ""
+"`Introductory workshop: PostGIS Topology Workshop "
+"<https://postgis.net/workshops/en/postgis-intro/topology.html>`_"
 msgstr ""
-"I den här workshopen kommer vi att gå igenom några grundläggande principer "
-"för topologi, dess grunder och definitioner. Det är inte tänkt att vara ett "
-"sätt att använda dem direkt, utan att förstå det för att sedan kunna använda "
-"det enkelt."
 
-#: ../../en/topology_base_types.rst:18
-msgid "Types"
-msgstr "Types"
-
-#: ../../en/topology_base_types.rst:23
-msgid "The basic topology works on three basic types."
-msgstr "Den grundläggande topologin fungerar på tre grundläggande typer."
-
-#: ../../en/topology_base_types.rst:25
-msgid "Node: 2D point, everything starts or ends here"
-msgstr "Node: 2D-punkt, allt börjar eller slutar här"
-
-#: ../../en/topology_base_types.rst:26
-msgid "Edge: A linestring with direction that start and ends on a node"
-msgstr "Edge: En linestring med riktning som börjar och slutar på en nod"
-
-#: ../../en/topology_base_types.rst:27
-msgid "Face: Closed set of linestrings, that conforms a polygon"
-msgstr "Face: Sluten uppsättning linestrings, som anpassar sig till en polygon"
-
-#: ../../en/topology_base_types.rst:29
-msgid "There are some rules for a set of nodes, edges and faces to be valid, check the ISO Topology document, has a very good summary of these conditions, a topology that follows all the rules, is a valid topology."
+#: ../../en/topology_topo_types.rst:11
+msgid ""
+"Having a Topology with all its Primitives is useful, but to make it more "
+"practical, we need a way to represent these elements in a table. Similar to "
+"how we have spatial tables, we can have topology tables."
 msgstr ""
-"Det finns vissa regler för att en uppsättning noder, kanter och ytor ska "
-"vara giltiga, se ISO Topology-dokumentet, som har en mycket bra "
-"sammanfattning av dessa villkor, en topologi som följer alla regler är en "
-"giltig topologi."
 
-#: ../../en/topology_base_types.rst:31
-msgid "Is good to know, until now Postgis will save all this information internally, each type has its own unique ID, and with it we can edit and change them using the available functions, for example with ST_RemEdgeNewFace you can remove an edge and create a new face."
+#: ../../en/topology_topo_types.rst:14
+msgid "Introduction to geometry representation"
 msgstr ""
-"Det är bra att veta, fram till nu sparar Postgis all denna information "
-"internt, varje typ har sitt eget unika ID, och med det kan vi redigera och "
-"ändra dem med hjälp av tillgängliga funktioner, till exempel med "
-"ST_RemEdgeNewFace kan du ta bort en kant och skapa en ny yta."
 
-#: ../../en/topology_base_types.rst:33
-msgid "But there is still a missing piece, how do we say for example, a face has a specific attribute? Postgis implements several concepts to do this like Layers, TopoGeometry, TopoElement."
+#: ../../en/topology_topo_types.rst:16
+msgid ""
+"If you have followed any example of using Topology to represent geometries "
+"you could remember this, when we populate a Topology table from a Geometry "
+"one we use TopoGeometries instead of Geometries, and in some way each "
+"TopoGeometry is able to represent one or several Primitives contained on the"
+" Topology."
 msgstr ""
-"Men det finns fortfarande en sak som saknas, hur säger vi till exempel att "
-"en yta har ett specifikt attribut? Postgis implementerar flera koncept för "
-"att göra detta som Layers, TopoGeometry, TopoElement."
 
-#: ../../en/topology_base_types.rst:36
-msgid "Universal Face"
-msgstr "Universal Face"
-
-#: ../../en/topology_base_types.rst:38
-msgid "It Might be intuitive to think that only the faces constructed by edges exist, there is one exception, all the white space out of all the faces is also a face!"
+#: ../../en/topology_topo_types.rst:21
+msgid ""
+"The point is how we reach the actual primitives from the TopoGeometry, how "
+"the data is structured, so first lets see the most global definitions:"
 msgstr ""
-"Det kan vara intuitivt att tro att bara de faces som konstrueras av kanter "
-"existerar, men det finns ett undantag: allt vitt utrymme bland alla faces är "
-"också ett face!"
 
-#: ../../en/topology_base_types.rst:40
-msgid "The empty space is called the Universal Face, when a Topology is empty, all the space is the Universal Face, when we add a linestring is an edge of this face, then when we make a polygon it is like make a hole in the face and stealing it to assign it to a face."
+#: ../../en/topology_topo_types.rst:26
+msgid ""
+"A TopoGeometry can represent a group of Primitives or other TopoGeometries, "
+"in order to create a TopoGeometry you need a Layer."
 msgstr ""
-"Det tomma utrymmet kallas Universal Face, när en topologi är tom är allt "
-"utrymme Universal Face, när vi lägger till en linestring är en kant av denna "
-"yta, när vi sedan gör en polygon är det som att göra ett hål i ytan och "
-"stjäla det för att tilldela det till en yta."
 
-#: ../../en/topology_base_types.rst:42
-msgid "This face is infinite and does not have any boundary."
-msgstr "Denna yta är oändlig och har inte någon gräns."
-
-#: ../../en/topology_base_types.rst:49
-msgid "The Universal Face has the ID 0."
-msgstr "Universal Face har ID 0."
-
-#: ../../en/topology_base_types.rst:52
-msgid "Edge interpretation"
-msgstr "Tolkning av kanter"
-
-#: ../../en/topology_base_types.rst:54
-msgid "To correctly represent a topology and their forms, there are some definitions that are used to construct the tables that store everything, the edge is on the more complex ones."
+#: ../../en/topology_topo_types.rst:28
+msgid ""
+"Layers are the biggest box, they store TopoGeometries which also stores "
+"TopoElements, this last ones represents Primitives or other TopoGeometries."
 msgstr ""
-"För att korrekt representera en topologi och dess former finns det vissa "
-"definitioner som används för att konstruera de tabeller som lagrar allt, "
-"kanten är på de mer komplexa."
 
-#: ../../en/topology_base_types.rst:56
-msgid "All the information about edges is stored on the edge_data table, in your custom topology schema, and which information do we need in the edges? basically its nodes and faces information, edge is the primitive who connects both."
+#: ../../en/topology_topo_types.rst:31
+msgid "Just to write in two ways:"
 msgstr ""
-"All information om kanter lagras i tabellen edge_data, i ditt anpassade "
-"topologischema, och vilken information behöver vi i kanterna? i princip är "
-"det information om noder och ytor, kanten är den primitiva som förbinder "
-"båda."
 
-#: ../../en/topology_base_types.rst:58
-msgid "These linestrings are called Edges because they are the edges of the faces."
-msgstr "Dessa linestrings kallas Edges eftersom de är kanterna på ytorna."
-
-#: ../../en/topology_base_types.rst:61
-msgid "Edge direction, left and right"
-msgstr "Kantriktning, vänster och höger"
-
-#: ../../en/topology_base_types.rst:63
-msgid "Edges in topology has a right defined perspective and view, when we see them must be done in the next way:"
+#: ../../en/topology_topo_types.rst:33
+msgid "Layer contains"
 msgstr ""
-"Kanter i topologin har ett rätt definierat perspektiv och vy, när vi ser dem "
-"måste det göras på nästa sätt:"
 
-#: ../../en/topology_base_types.rst:68
-msgid "When we want to see from the edge perspective is always from the end node to the start edge, always looking the edge forward."
+#: ../../en/topology_topo_types.rst:35
+msgid ""
+"TopoGeometries where all of them has the same TopoElement's type, each one "
+"one contains:"
 msgstr ""
-"När vi vill se från kantperspektivet är det alltid från slutnoden till "
-"startkanten, alltid med kanten framåt."
 
-#: ../../en/topology_base_types.rst:74
-msgid "The edges have left and right properties, as we see they are defined using the edge perspective, see the linestring from the start node to the end node, there will always be a well defined left and right."
+#: ../../en/topology_topo_types.rst:37
+msgid "TopoElements where each one can represent a:"
 msgstr ""
-"Kanterna har vänster- och högeregenskaper, som vi ser definieras de med "
-"hjälp av kantperspektivet, se linjesträngen från startnoden till slutnoden, "
-"det kommer alltid att finnas en väldefinierad vänster och höger."
 
-#: ../../en/topology_base_types.rst:76
-msgid "So see the edge forward and you always have a left and right side."
-msgstr "Så se kanten framåt och du har alltid en vänster och en höger sida."
-
-#: ../../en/topology_base_types.rst:78
-msgid "This helps to relate which faces are on each side of the edge:"
+#: ../../en/topology_topo_types.rst:39
+msgid "TopoGeometry of other Layer"
 msgstr ""
-"Detta hjälper till att relatera vilka ytor som finns på vardera sidan av "
-"kanten:"
 
-#: ../../en/topology_base_types.rst:83
-msgid "Check the edges on the image, while almost all the edges go from down to up and left to right, there is an orange edge which has the opposite direction, so its sides left and right are swapped in reference to the others, but if you look the edge forward, the right and left are right."
+#: ../../en/topology_topo_types.rst:40
+msgid "Geometry Collection"
 msgstr ""
-"Kontrollera kanterna på bilden, medan nästan alla kanter går från ner till "
-"upp och från vänster till höger, finns det en orange kant som har motsatt "
-"riktning, så dess sidor vänster och höger är ombytta i förhållande till de "
-"andra, men om du tittar på kanten framåt är höger och vänster rätt."
 
-#: ../../en/topology_base_types.rst:85
-msgid "Continue seeing the orange edge, while on its right has a polygon built by the edges, on the left is the Universal Face."
+#: ../../en/topology_topo_types.rst:41
+msgid "Primitive from the Topology"
 msgstr ""
-"Fortsätt att se den orange kanten, medan den till höger har en polygon byggd "
-"av kanterna, till vänster är Universal Face."
 
-#: ../../en/topology_base_types.rst:87
-msgid "When we want to analyze any edge, and we need to see it from the edge perspective, it is always looking the edge in forward, never in backward!"
+#: ../../en/topology_topo_types.rst:43 ../../en/topology_topo_types.rst:62
+msgid "Nodes"
 msgstr ""
-"När vi vill analysera en kant, och vi måste se den från kantperspektivet, är "
-"det alltid att titta på kanten framåt, aldrig bakåt!"
 
-#: ../../en/topology_base_types.rst:89
-msgid "Which are all the next edges? Looking forward we go from start node to the end node, all the edges who start or end in the end node of the edge!"
+#: ../../en/topology_topo_types.rst:44 ../../en/topology_topo_types.rst:63
+msgid "Edges"
 msgstr ""
-"Vilka är alla de kommande kanterna? Om vi tittar framåt går vi från "
-"startnoden till slutnoden, alla kanter som börjar eller slutar i kantnoden!"
 
-#: ../../en/topology_base_types.rst:92
-msgid "Edge Data"
-msgstr "Kantdata"
-
-#: ../../en/topology_base_types.rst:94
-msgid "The edge_data table has information related to the edge, from what we know right now we can interpret the next columns:"
+#: ../../en/topology_topo_types.rst:45 ../../en/topology_topo_types.rst:64
+msgid "Faces"
 msgstr ""
-"Tabellen edge_data innehåller information om kanten, utifrån vad vi vet just "
-"nu kan vi tolka nästa kolumner:"
 
-#: ../../en/topology_base_types.rst:96
-msgid "edge_id: Unique ID for the edge"
-msgstr "edge_id: Unikt ID för kanten"
-
-#: ../../en/topology_base_types.rst:97
-msgid "start_node: ID for the node who is the same as the start point of the edge"
-msgstr "start_node: ID för den nod som är densamma som startpunkten för kanten"
-
-#: ../../en/topology_base_types.rst:98
-msgid "end_node: ID for the node who is the same as the end point of the edge"
-msgstr "end_node: ID för den nod som är densamma som slutpunkten för kanten"
-
-#: ../../en/topology_base_types.rst:99
-msgid "left_face: ID of the face on the left of the edge"
-msgstr "left_face: ID för ytan till vänster om kanten"
-
-#: ../../en/topology_base_types.rst:100
-msgid "right_face: ID of the face on the right of the edge"
-msgstr "right_face: ID för ytan till höger om kanten"
-
-#: ../../en/topology_base_types.rst:101
-msgid "geom: Geometry of the edge"
-msgstr "geom: Geometri för kanten"
-
-#: ../../en/topology_base_types.rst:104
-msgid "Abs Next Edge & Next Edge"
-msgstr "Abs Next Edge & Next Edge"
-
-#: ../../en/topology_base_types.rst:106
-msgid "The table edge_data has the columns abs_next_left_edge and abs_next_right_edge, at this moment it gets a little tricky how to interpret it."
+#: ../../en/topology_topo_types.rst:47
+msgid ""
+"TopoGeometries are exposed as keys, they has a unique key inside the Layer, "
+"but also stores its Layer Key, this allows Postgis to store it in an "
+"arbitrary column and always be able to find its TopoElements, and with them "
+"what they represent."
 msgstr ""
-"Tabellen edge_data har kolumnerna abs_next_left_edge och "
-"abs_next_right_edge, och nu blir det lite knepigt att tolka dem."
 
-#: ../../en/topology_base_types.rst:108
-msgid "Until now we mainly see properties of the edge itself and what has on the sides, the next edge properties are different, do not ask only about the edge itself, it is about which is the next edge who builds the face on the right or left."
+#: ../../en/topology_topo_types.rst:49
+msgid ""
+"You need a Layer where a TopoGeometry will be constructed, and after that "
+"you don't need to remember to which Layer it belongs."
 msgstr ""
-"Hittills har vi främst sett egenskaper hos själva kanten och vad som har på "
-"sidorna, nästa kants egenskaper är annorlunda, fråga inte bara om själva "
-"kanten, det handlar om vilken som är nästa kant som bygger ytan till höger "
-"eller vänster."
 
-#: ../../en/topology_base_types.rst:110
-msgid "The logic of the right_edge and the left_edge are very similar, so we will look first on the left one deeper and then show the right one."
+#: ../../en/topology_topo_types.rst:51
+msgid ""
+"This concept is the one used for the user, from this point we will explain "
+"deep and technical details."
 msgstr ""
-"Logiken för höger_kant och vänster_kant är mycket lika, så vi kommer först "
-"att titta på den vänstra djupare och sedan visa den högra."
 
-#: ../../en/topology_base_types.rst:112
-msgid "We will be using the next topology as example:"
-msgstr "Vi kommer att använda nästa topologi som exempel:"
-
-#: ../../en/topology_base_types.rst:119
-msgid "Left"
-msgstr "Vänster"
-
-#: ../../en/topology_base_types.rst:121
-msgid "Let's pick as an example the Edge 5, this one has on the Left the Face 2, looking forward which is the next edge who builds the Face 2?"
+#: ../../en/topology_topo_types.rst:53
+msgid ""
+"As a side note, Postgis Topology has internally some tricks when its about "
+"keys, helps to optimize a lot of parts but at the same time there is a lot "
+"of reduntant information, do not be supreised if you find the same "
+"information in two or more places."
 msgstr ""
-"Låt oss ta Edge 5 som exempel, den här har till vänster Face 2, om vi tittar "
-"framåt vilken är nästa edge vem bygger Face 2?"
 
-#: ../../en/topology_base_types.rst:123
-msgid "This is the Edge 6."
-msgstr "Det här är Edge 6."
-
-#: ../../en/topology_base_types.rst:129
-msgid "Something very important here is the perspective we follow the lines, depending on the Edge direction, is like see the Face clockwise or anticlockwise."
+#: ../../en/topology_topo_types.rst:56
+msgid "Features"
 msgstr ""
-"Något mycket viktigt här är perspektivet vi följer linjerna, beroende på "
-"kantriktningen, är det som att se detta face medurs eller moturs."
 
-#: ../../en/topology_base_types.rst:131
-msgid "With this information we have abs_next_left_edge which will be 6."
-msgstr "Med denna information har vi abs_next_left_edge som kommer att vara 6."
-
-#: ../../en/topology_base_types.rst:133
-msgid "The next_left_edge is almost the same as abs_next_left_edge, except it can be negative which depends on the perspective we see the edge."
+#: ../../en/topology_topo_types.rst:58
+msgid ""
+"TopoElements can represent a TopoGeometry and a Primitive, think in a "
+"TopoGeometry, if store them in a TopoElement, they still contain other "
+"TopoElements, if we follow its path we will always ends in Primitives of the"
+" Topology."
 msgstr ""
-"next_left_edge är nästan samma sak som abs_next_left_edge, förutom att den "
-"kan vara negativ, vilket beror på vilket perspektiv vi ser kanten från."
 
-#: ../../en/topology_base_types.rst:135
-msgid "If we follow the Edge perspective we will have two directions, the direction of the next edge, and the direction of the perspective on the next edge."
+#: ../../en/topology_topo_types.rst:60
+msgid ""
+"Features will represent which type the set of geometries will be, is not "
+"important if you use TopoGeometries or Primitives, in the end a Layer can "
+"contain directly or indirectly any of this sets:"
 msgstr ""
-"Om vi följer Edge-perspektivet kommer vi att ha två riktningar, riktningen "
-"mot nästa kant och riktningen för perspektivet på nästa kant."
 
-#: ../../en/topology_base_types.rst:137
-msgid "We will use the next sign in each case:"
-msgstr "Vi kommer att använda nästa tecken i varje fall:"
-
-#: ../../en/topology_base_types.rst:139
-msgid "Perspective direction and Next edge direction are opposed: \"-\""
-msgstr "Perspektivriktning och riktning mot nästa kant är motsatta: \"-\""
-
-#: ../../en/topology_base_types.rst:140
-msgid "Perspective direction and Next edge direction are the same: None, keep the value positive"
+#: ../../en/topology_topo_types.rst:65
+msgid "Geometry Collections"
 msgstr ""
-"Perspektivriktningen och Next edge-riktningen är desamma: None, behåll "
-"värdet positivt"
 
-#: ../../en/topology_base_types.rst:142
-msgid "How the Perspective and Edge 6 have the same direction, next_left_edge will be 6."
+#: ../../en/topology_topo_types.rst:67
+msgid ""
+"The numbers are important, in any function which requests the Feature Type, "
+"you can specify it using the number or the name as string."
 msgstr ""
-"Eftersom perspektivet och Edge 6 har samma riktning kommer next_left_edge "
-"att vara 6."
 
-#: ../../en/topology_base_types.rst:144
-msgid "abs_next_left_edge: 6"
-msgstr "abs_next_left_edge: 6"
-
-#: ../../en/topology_base_types.rst:145
-msgid "next_left_edge: 6"
-msgstr "next_left_edge: 6"
-
-#: ../../en/topology_base_types.rst:148
-msgid "Right"
-msgstr "Höger"
-
-#: ../../en/topology_base_types.rst:150
-msgid "The only difference between Left and Right analysis is the perspective, while in Left we use forward, in Right we will see backwards. Be careful, even if we look backwards the definition of Left Face and Right Face are still the same, looking forward! Only changes the perspective to follow."
+#: ../../en/topology_topo_types.rst:70
+msgid "Hierarchical Layers, Childs and Parents"
 msgstr ""
-"Den enda skillnaden mellan vänster och höger analys är perspektivet, medan "
-"vi i vänster använder framåt, kommer vi i höger att se bakåt. Var försiktig, "
-"även om vi tittar bakåt är definitionen av Left Face och Right Face "
-"fortfarande densamma, framåtblickande! Det är bara perspektivet som ändras."
 
-#: ../../en/topology_base_types.rst:152
-msgid "The Edge 5 has the Face 0 on its Right, the Universal Face, looking Edge 5 backwards the next edge who builds Face 0 is the Edge 4."
+#: ../../en/topology_topo_types.rst:72
+msgid ""
+"I would like to introduce this concept later, but to explain better and "
+"deeper the concept you will find this is needed."
 msgstr ""
-"Edge 5 har Face 0 på sin högra sida, Universal Face, om man tittar Edge 5 "
-"bakåt är nästa kant som bygger Face 0 Edge 4."
 
-#: ../../en/topology_base_types.rst:158
-msgid "Following the perspective of Edge 5 on Edge 4 we can see it goes up, while the Edge 4 goes down, the Perspective direction and the Edge 4 direction are opposed."
+#: ../../en/topology_topo_types.rst:77
+msgid ""
+"The first aspect on the image is a table that is constructed using "
+"Primitives, Layer 1 will have TopoGeometries where its TopoElements only "
+"make a reference to Primitives of the topology."
 msgstr ""
-"Om vi följer perspektivet för Edge 5 på Edge 4 kan vi se att den går upp, "
-"medan Edge 4 går ner, perspektivets riktning och Edge 4:s riktning är "
-"motsatta."
 
-#: ../../en/topology_base_types.rst:160
-msgid "abs_next_right_edge: 4"
-msgstr "abs_next_right_edge: 4"
-
-#: ../../en/topology_base_types.rst:161
-msgid "nexr_right_edge: -4 (Perspective direction and Edge 4 direction are opposed)"
+#: ../../en/topology_topo_types.rst:79
+msgid "We define the relationship between Layer 1 and Primitives as:"
 msgstr ""
-"nexr_right_edge: -4 (Perspektivriktning och Edge 4-riktning är motsatta)"
 
-#: ../../en/topology_base_types.rst:164
-msgid "Isolated Edge Case"
-msgstr "Isolerat kantfall"
-
-#: ../../en/topology_base_types.rst:166
-msgid "There is a case that may be confusing, all the rules above follow in the same way but it is good to take a look."
+#: ../../en/topology_topo_types.rst:81
+msgid "Layer 1 is Parent of the Primitives"
 msgstr ""
-"Det finns ett fall som kan vara förvirrande, alla regler ovan följer på "
-"samma sätt men det är bra att ta en titt."
 
-#: ../../en/topology_base_types.rst:172
-msgid "When we have an Edge that has no connections to other Edges, the first thing we can appreciate is that the Face of the Left is the same as the Right, in this case Face 0, the Universal Face."
+#: ../../en/topology_topo_types.rst:82
+msgid "Primitives are Childs of the Layer 1"
 msgstr ""
-"När vi har en kant som inte har några kopplingar till andra kanter är det "
-"första vi kan förstå att vänstersidan är densamma som högersidan, i det här "
-"fallet Face 0, Universal Face."
 
-#: ../../en/topology_base_types.rst:174
-msgid "If we follow the past logic, on the Left is the Face 0, which is the next edge who builds Face 0? Actually there is an Edge, and is itself, and it also has a perspective as before:"
+#: ../../en/topology_topo_types.rst:84
+msgid ""
+"The relation between Parent and Child is about the size, Childs are small, "
+"when we have a group of them we build a Parent, a bigger group."
 msgstr ""
-"Om vi följer den tidigare logiken, till vänster är Face 0, vilket är nästa "
-"kant som bygger Face 0? Det finns faktiskt en kant, och den är sig själv, "
-"och den har också ett perspektiv som tidigare:"
 
-#: ../../en/topology_base_types.rst:180
-msgid "If we check the perspective direction we ends looking the same edge but in opposite direction, this means the Edge 1 and its Next Edge (Edge 1) has opposed directions."
+#: ../../en/topology_topo_types.rst:86
+msgid ""
+"Layer 2 has as childs the Layer 1, this implies each TopoGeometry from this "
+"layer, can make a reference to one or multiple TopoGeometries of the Layer "
+"1."
 msgstr ""
-"Om vi kontrollerar perspektivriktningen slutar vi titta på samma kant men i "
-"motsatt riktning, vilket innebär att Edge 1 och dess nästa kant (Edge 1) har "
-"motsatta riktningar."
 
-#: ../../en/topology_base_types.rst:182
-#: ../../en/topology_base_types.rst:194
-msgid "edge_id: 1"
-msgstr "edge_id: 1"
-
-#: ../../en/topology_base_types.rst:183
-msgid "abs_next_left_edge: 1"
-msgstr "abs_next_left_edge: 1"
-
-#: ../../en/topology_base_types.rst:184
-msgid "next_left_edge: -1 (This will always be negative while we see forward a isolated edge)"
+#: ../../en/topology_topo_types.rst:88
+msgid ""
+"This also means you can't pick half of a TopoGeometry from Layer 1, pick "
+"half of it means you need a reference to one of the TopoElements of a "
+"TopoGeometry, which in this case belongs to the Primitives (its Child), if "
+"you really need that then build Layer 2 using Layer 1 childs (Primitives)."
 msgstr ""
-"next_left_edge: -1 (Detta kommer alltid att vara negativt när vi ser framåt "
-"en isolerad kant)"
 
-#: ../../en/topology_base_types.rst:186
-msgid "For the Next Right Edge is the same, the Next Edge will be it self, the only what it changes is the perspective:"
+#: ../../en/topology_topo_types.rst:90
+msgid ""
+"Each Layer can only have one Child Layer, this means, the Child and Parent "
+"share the same Topology schema."
 msgstr ""
-"För nästa högra kant är densamma, nästa kant kommer att vara sig själv, det "
-"enda som förändras är perspektivet:"
 
-#: ../../en/topology_base_types.rst:192
-msgid "When we look backwards any isolated edge, the perspective will always have the same direction as the Edge so:"
+#: ../../en/topology_topo_types.rst:92
+msgid ""
+"You will notice some aspects of Hierarchy could change to maybe support "
+"something like half TopoGeometry or mixing Layers, but right now is not "
+"implemented."
 msgstr ""
-"När vi tittar bakåt på en isolerad kant kommer perspektivet alltid att ha "
-"samma riktning som kanten:"
 
-#: ../../en/topology_base_types.rst:195
-msgid "abs_next_right_edge: 1"
-msgstr "abs_next_right_edge: 1"
-
-#: ../../en/topology_base_types.rst:196
-msgid "next_right_edge: -1 (This will always be positive while we see backwar a isolated edge)"
+#: ../../en/topology_topo_types.rst:95
+msgid "Layers"
 msgstr ""
-"next_right_edge: -1 (Detta kommer alltid att vara positivt medan vi ser "
-"bakåt en isolerad kant)"
 
-#: ../../en/topology_base_types.rst:199
-msgid "Full columns of edge_data"
-msgstr "Fullständiga kolumner av edge_data"
-
-#: ../../en/topology_base_types.rst:201
-msgid "We already checked all the columns of the edge_data table:"
-msgstr "Vi har redan kontrollerat alla kolumner i tabellen edge_data:"
-
-#: ../../en/topology_base_types.rst:203
-msgid "edge_id: Unique ID for the edge."
-msgstr "edge_id: Unikt ID för kanten."
-
-#: ../../en/topology_base_types.rst:204
-msgid "start_node: ID for the node which is the same as the start point of the edge."
-msgstr "start_node: ID för den nod som är densamma som startpunkten för kanten."
-
-#: ../../en/topology_base_types.rst:205
-msgid "end_node: ID for the node which is the same as the end point of the edge."
-msgstr "end_node: ID för den nod som är densamma som slutpunkten för kanten."
-
-#: ../../en/topology_base_types.rst:206
-msgid "left_face: ID of the face on the left of the edge."
-msgstr "left_face: ID för den yta som ligger till vänster om kanten."
-
-#: ../../en/topology_base_types.rst:207
-msgid "abs_next_left_edge: Next edge who builds the face on the left."
-msgstr "abs_next_left_edge: Nästa kant som bygger ytan till vänster."
-
-#: ../../en/topology_base_types.rst:208
-msgid "next_left_edge: abs_next_left_edge and negative sign if the right face is on the right of the next left edge."
+#: ../../en/topology_topo_types.rst:97
+msgid ""
+"To store TopoGeometries we need a Layer, due to this when we create a "
+"TopoGeometrie's Column, we also create a Layer, this is why we use a special"
+" function to create a column for this."
 msgstr ""
-"next_left_edge: abs_next_left_edge och negativt tecken om den högra sidan är "
-"till höger om nästa vänstra kant."
 
-#: ../../en/topology_base_types.rst:209
-msgid "right_face: ID of the face on the right of the edge."
-msgstr "right_face: ID för ytan till höger om kanten."
-
-#: ../../en/topology_base_types.rst:210
-msgid "abs_next_right_edge: Next edge who builds the face on the right."
-msgstr "abs_next_right_edge: Nästa kant som bygger ytan till höger."
-
-#: ../../en/topology_base_types.rst:211
-msgid "next_right_edge: abs_next_right_edge and negative sign if the left face is on the right of the next right edge."
+#: ../../en/topology_topo_types.rst:99
+msgid ""
+"`Crete TopoGeometry Column "
+"<https://postgis.net/docs/AddTopoGeometryColumn.html>`_"
 msgstr ""
-"next_right_edge: abs_next_right_edge och negativt tecken om den vänstra "
-"sidan är till höger om nästa högra kant."
 
-#: ../../en/topology_base_types.rst:212
-msgid "geom: Geometry of the edge."
-msgstr "geom: Geometri för kanten."
+#: ../../en/topology_topo_types.rst:101
+msgid ""
+"Layers and TopoGeometry Columns have a special relationship, they are "
+"linked, but they are not the same."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:103
+msgid ""
+"Layers have a lot of information that we must provide to know which type of "
+"Layer we want."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:105
+msgid ""
+"Layers have a unique identifier in each topology, this identifier is called "
+"layer_id."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:107
+msgid "Layers Key: Composed Key with [topology_id, layer_id]"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:108
+msgid ""
+"Table route: Schema name, table name and column name to know where it is "
+"linked."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:109
+msgid "Feature Type: Feature type the layer will contain."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:110
+msgid ""
+"Level: This value starts at 0, in the case we construct this layer using "
+"another layer, it will add 1, so we know how many layers we are from the "
+"Primitives, if the value is 0 means the Layer is constructed using "
+"Primitives instead of TopoGeometries."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:111
+msgid ""
+"child_id: In case the layer is built not using Primitives and using another "
+"Layer as base, we need the Layer Identifier (layer_id) of this layer, we do "
+"not need topology_id because we already know it from the parent."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:114
+msgid "Relation's Table"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:116
+msgid ""
+"Finally, the section you may be looking at, how Postgis Topology goes from a"
+" TopoGeometry to what they contain."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:118
+msgid ""
+"The Relation's table function is be the bridge between the Parent and "
+"Childs."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:120
+msgid "This table can be found in: ``my_topology.relation``."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:123
+msgid "Keys and Identifiers we know now"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:125
+msgid ""
+"I'll use the word \"Identifier\" as a unique key in a particular context. "
+"For example each layer has a number as an identifier (layer_id), it is "
+"unique in its topology context, but is not enough to find a layer in a "
+"database."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:127
+msgid ""
+"While Identifiers will work in a context, the Key will be the full way to "
+"address an element, for example the key for any layer are two values "
+"[topology_id, layer_id]."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:133
+msgid "The image is a good summary of how the keys for each are composed."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:136
+msgid "Implicit identifiers on Keys"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:138
+msgid ""
+"Postgis uses at some extent an implicit logic when working with Layers and "
+"TopoGeometries, this is because they have a context where you don't need to "
+"store the full Key to know it."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:140
+msgid "To show an example:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:142
+msgid "TopoGeometry is composed by:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:144
+msgid "topology_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:145
+msgid "layer_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:146
+msgid "topogeometry_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:148
+msgid ""
+"As we said before, the relation's table is stored inside the topology "
+"schema. This table will contain the relation of the TopoGeometry with the "
+"TopoElements, to make a reference in this context, do we need the "
+"topology_id?"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:150
+msgid ""
+"We can skip it! While we are out of the topology schema we need the id to "
+"find it, but while we are inside it we can look at the schema name, and find"
+" its id on the table ``topology.topology``, which has all topologies ids and"
+" names."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:153
+msgid "TopoGeometry"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:155
+msgid "TopoGeometry is a composite key with the next elements:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:157
+msgid "topology_id: topology_id of TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:158
+msgid "layer_id: layer_id of the TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:159
+msgid "id: topogeometry_id of the TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:160
+msgid "type: Feature type as number"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:163
+msgid "Basic Relation's table structure"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:165
+msgid ""
+"Each schema topology can have its own relation's table, it will be created "
+"when you create your first TopoGeometry, the table is stored inside the "
+"topology as ``custom_topology.relation``."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:167
+msgid ""
+"Each row of the table is called a \"Component\", like a component of the "
+"relations."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:169
+msgid ""
+"The component saves pairs of two things, a TopoGeometry Key and a "
+"TopoElement, remember that each TopoElement can only represent one Primitive"
+" or TopoGeometry, so for a TopoGeometry be able to represent several of them"
+" the tables stores multiple rows with the same TopoGeometry Key and "
+"different TopoElements, this way only filtering in the table we can get all "
+"the TopoElements for any TopoGeometry."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:176
+msgid "Find Components of a TopoGeometry"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:178
+msgid ""
+"To find which components belong to a TopoGeometry is a little tricky, "
+"because here will work the implicit Keys."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:180
+msgid "A component has the next elements:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:182
+msgid "TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:184
+msgid "topogeom_id: topogeometry_id from TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:185
+msgid "layer_id: layer_id from TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:187
+msgid "TopoElement"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:189
+msgid "element_id"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:190
+msgid "element_type"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:192
+msgid ""
+"We can notice the TopoGeometry Key is incomplete, this is because the "
+"relation's table already belongs to a topology, so there is no need to store"
+" the topology identifier again."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:194
+msgid ""
+"To reach from a TopoGeometry to a Component we need to look the "
+"TopoGeometry.topology_id and search on ``topology.topology.id`` and retrieve"
+" the Topology Name, with it we can found the relation's table in their "
+"respective schema."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:201
+msgid "Reading TopoElements"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:203
+msgid ""
+"The last part to decompose TopoGeometry is to be able to interpret the "
+"TopoElements which is more complex than other keys, because its meaning can "
+"change based on the Layer it is saved."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:205
+msgid ""
+"As we talked, a Layer can have as Childs two options, Primitives or "
+"TopoGeometries."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:207
+msgid ""
+"The first we need to know is which Childs it is using, for this we need to "
+"look on ``topology.layer.id`` using the ``TopoGeometry Key.layer_id`` and "
+"get ```topology.layer.child_id```."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:209
+msgid "So the cases depends on child_id:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:211
+msgid "If is NULL:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:213
+msgid "element_id: Primitive Identifier"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:214
+msgid ""
+"element_type: Feature number, look on the Features to know to which "
+"primitive table too look on."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:216
+msgid "If is not NULL:"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:218
+msgid "element_id: topogeometry_id from a TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:219
+msgid "element_type: layer_id from a TopoGeometry Key"
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:221
+msgid ""
+"The first case is trivial, just look at their respective Primitive table and"
+" use the identifier to know which primitive is."
+msgstr ""
+
+#: ../../en/topology_topo_types.rst:223
+msgid ""
+"While the second case the TopoElement is used to build a new TopoGeometry "
+"Key, the topology_id is implicit as we talked, so the Key is complete, to "
+"find the new elements look again on the relation's table but using the new "
+"keys."
+msgstr ""
+
+#~ msgid "Topology Basic Types"
+#~ msgstr "Grundläggande topologityper"
+
+#~ msgid ""
+#~ "`ISO Topology: OGC-SFS Geometries <https://www.gaia-"
+#~ "gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+#~ msgstr ""
+#~ "`ISO Topology: OGC-SFS Geometries <https://www.gaia-"
+#~ "gis.it/fossil/libspatialite/wiki?name=topo-intro>`_."
+
+#~ msgid ""
+#~ "In this workshop, we will check some fundamentals of topology, its basics "
+#~ "and definitions. It is not intended to be a way to use them directly, is to "
+#~ "understand it to then be able to use it easily."
+#~ msgstr ""
+#~ "I den här workshopen kommer vi att gå igenom några grundläggande principer "
+#~ "för topologi, dess grunder och definitioner. Det är inte tänkt att vara ett "
+#~ "sätt att använda dem direkt, utan att förstå det för att sedan kunna använda"
+#~ " det enkelt."
+
+#~ msgid "Types"
+#~ msgstr "Types"
+
+#~ msgid "The basic topology works on three basic types."
+#~ msgstr "Den grundläggande topologin fungerar på tre grundläggande typer."
+
+#~ msgid "Node: 2D point, everything starts or ends here"
+#~ msgstr "Node: 2D-punkt, allt börjar eller slutar här"
+
+#~ msgid "Edge: A linestring with direction that start and ends on a node"
+#~ msgstr "Edge: En linestring med riktning som börjar och slutar på en nod"
+
+#~ msgid "Face: Closed set of linestrings, that conforms a polygon"
+#~ msgstr ""
+#~ "Face: Sluten uppsättning linestrings, som anpassar sig till en polygon"
+
+#~ msgid ""
+#~ "There are some rules for a set of nodes, edges and faces to be valid, check "
+#~ "the ISO Topology document, has a very good summary of these conditions, a "
+#~ "topology that follows all the rules, is a valid topology."
+#~ msgstr ""
+#~ "Det finns vissa regler för att en uppsättning noder, kanter och ytor ska "
+#~ "vara giltiga, se ISO Topology-dokumentet, som har en mycket bra "
+#~ "sammanfattning av dessa villkor, en topologi som följer alla regler är en "
+#~ "giltig topologi."
+
+#~ msgid ""
+#~ "Is good to know, until now Postgis will save all this information "
+#~ "internally, each type has its own unique ID, and with it we can edit and "
+#~ "change them using the available functions, for example with "
+#~ "ST_RemEdgeNewFace you can remove an edge and create a new face."
+#~ msgstr ""
+#~ "Det är bra att veta, fram till nu sparar Postgis all denna information "
+#~ "internt, varje typ har sitt eget unika ID, och med det kan vi redigera och "
+#~ "ändra dem med hjälp av tillgängliga funktioner, till exempel med "
+#~ "ST_RemEdgeNewFace kan du ta bort en kant och skapa en ny yta."
+
+#~ msgid ""
+#~ "But there is still a missing piece, how do we say for example, a face has a "
+#~ "specific attribute? Postgis implements several concepts to do this like "
+#~ "Layers, TopoGeometry, TopoElement."
+#~ msgstr ""
+#~ "Men det finns fortfarande en sak som saknas, hur säger vi till exempel att "
+#~ "en yta har ett specifikt attribut? Postgis implementerar flera koncept för "
+#~ "att göra detta som Layers, TopoGeometry, TopoElement."
+
+#~ msgid "Universal Face"
+#~ msgstr "Universal Face"
+
+#~ msgid ""
+#~ "It Might be intuitive to think that only the faces constructed by edges "
+#~ "exist, there is one exception, all the white space out of all the faces is "
+#~ "also a face!"
+#~ msgstr ""
+#~ "Det kan vara intuitivt att tro att bara de faces som konstrueras av kanter "
+#~ "existerar, men det finns ett undantag: allt vitt utrymme bland alla faces är"
+#~ " också ett face!"
+
+#~ msgid ""
+#~ "The empty space is called the Universal Face, when a Topology is empty, all "
+#~ "the space is the Universal Face, when we add a linestring is an edge of this"
+#~ " face, then when we make a polygon it is like make a hole in the face and "
+#~ "stealing it to assign it to a face."
+#~ msgstr ""
+#~ "Det tomma utrymmet kallas Universal Face, när en topologi är tom är allt "
+#~ "utrymme Universal Face, när vi lägger till en linestring är en kant av denna"
+#~ " yta, när vi sedan gör en polygon är det som att göra ett hål i ytan och "
+#~ "stjäla det för att tilldela det till en yta."
+
+#~ msgid "This face is infinite and does not have any boundary."
+#~ msgstr "Denna yta är oändlig och har inte någon gräns."
+
+#~ msgid "The Universal Face has the ID 0."
+#~ msgstr "Universal Face har ID 0."
+
+#~ msgid "Edge interpretation"
+#~ msgstr "Tolkning av kanter"
+
+#~ msgid ""
+#~ "To correctly represent a topology and their forms, there are some "
+#~ "definitions that are used to construct the tables that store everything, the"
+#~ " edge is on the more complex ones."
+#~ msgstr ""
+#~ "För att korrekt representera en topologi och dess former finns det vissa "
+#~ "definitioner som används för att konstruera de tabeller som lagrar allt, "
+#~ "kanten är på de mer komplexa."
+
+#~ msgid ""
+#~ "All the information about edges is stored on the edge_data table, in your "
+#~ "custom topology schema, and which information do we need in the edges? "
+#~ "basically its nodes and faces information, edge is the primitive who "
+#~ "connects both."
+#~ msgstr ""
+#~ "All information om kanter lagras i tabellen edge_data, i ditt anpassade "
+#~ "topologischema, och vilken information behöver vi i kanterna? i princip är "
+#~ "det information om noder och ytor, kanten är den primitiva som förbinder "
+#~ "båda."
+
+#~ msgid ""
+#~ "These linestrings are called Edges because they are the edges of the faces."
+#~ msgstr "Dessa linestrings kallas Edges eftersom de är kanterna på ytorna."
+
+#~ msgid "Edge direction, left and right"
+#~ msgstr "Kantriktning, vänster och höger"
+
+#~ msgid ""
+#~ "Edges in topology has a right defined perspective and view, when we see them"
+#~ " must be done in the next way:"
+#~ msgstr ""
+#~ "Kanter i topologin har ett rätt definierat perspektiv och vy, när vi ser dem"
+#~ " måste det göras på nästa sätt:"
+
+#~ msgid ""
+#~ "When we want to see from the edge perspective is always from the end node to"
+#~ " the start edge, always looking the edge forward."
+#~ msgstr ""
+#~ "När vi vill se från kantperspektivet är det alltid från slutnoden till "
+#~ "startkanten, alltid med kanten framåt."
+
+#~ msgid ""
+#~ "The edges have left and right properties, as we see they are defined using "
+#~ "the edge perspective, see the linestring from the start node to the end "
+#~ "node, there will always be a well defined left and right."
+#~ msgstr ""
+#~ "Kanterna har vänster- och högeregenskaper, som vi ser definieras de med "
+#~ "hjälp av kantperspektivet, se linjesträngen från startnoden till slutnoden, "
+#~ "det kommer alltid att finnas en väldefinierad vänster och höger."
+
+#~ msgid "So see the edge forward and you always have a left and right side."
+#~ msgstr "Så se kanten framåt och du har alltid en vänster och en höger sida."
+
+#~ msgid "This helps to relate which faces are on each side of the edge:"
+#~ msgstr ""
+#~ "Detta hjälper till att relatera vilka ytor som finns på vardera sidan av "
+#~ "kanten:"
+
+#~ msgid ""
+#~ "Check the edges on the image, while almost all the edges go from down to up "
+#~ "and left to right, there is an orange edge which has the opposite direction,"
+#~ " so its sides left and right are swapped in reference to the others, but if "
+#~ "you look the edge forward, the right and left are right."
+#~ msgstr ""
+#~ "Kontrollera kanterna på bilden, medan nästan alla kanter går från ner till "
+#~ "upp och från vänster till höger, finns det en orange kant som har motsatt "
+#~ "riktning, så dess sidor vänster och höger är ombytta i förhållande till de "
+#~ "andra, men om du tittar på kanten framåt är höger och vänster rätt."
+
+#~ msgid ""
+#~ "Continue seeing the orange edge, while on its right has a polygon built by "
+#~ "the edges, on the left is the Universal Face."
+#~ msgstr ""
+#~ "Fortsätt att se den orange kanten, medan den till höger har en polygon byggd"
+#~ " av kanterna, till vänster är Universal Face."
+
+#~ msgid ""
+#~ "When we want to analyze any edge, and we need to see it from the edge "
+#~ "perspective, it is always looking the edge in forward, never in backward!"
+#~ msgstr ""
+#~ "När vi vill analysera en kant, och vi måste se den från kantperspektivet, är"
+#~ " det alltid att titta på kanten framåt, aldrig bakåt!"
+
+#~ msgid ""
+#~ "Which are all the next edges? Looking forward we go from start node to the "
+#~ "end node, all the edges who start or end in the end node of the edge!"
+#~ msgstr ""
+#~ "Vilka är alla de kommande kanterna? Om vi tittar framåt går vi från "
+#~ "startnoden till slutnoden, alla kanter som börjar eller slutar i kantnoden!"
+
+#~ msgid "Edge Data"
+#~ msgstr "Kantdata"
+
+#~ msgid ""
+#~ "The edge_data table has information related to the edge, from what we know "
+#~ "right now we can interpret the next columns:"
+#~ msgstr ""
+#~ "Tabellen edge_data innehåller information om kanten, utifrån vad vi vet just"
+#~ " nu kan vi tolka nästa kolumner:"
+
+#~ msgid "edge_id: Unique ID for the edge"
+#~ msgstr "edge_id: Unikt ID för kanten"
+
+#~ msgid ""
+#~ "start_node: ID for the node who is the same as the start point of the edge"
+#~ msgstr ""
+#~ "start_node: ID för den nod som är densamma som startpunkten för kanten"
+
+#~ msgid "end_node: ID for the node who is the same as the end point of the edge"
+#~ msgstr "end_node: ID för den nod som är densamma som slutpunkten för kanten"
+
+#~ msgid "left_face: ID of the face on the left of the edge"
+#~ msgstr "left_face: ID för ytan till vänster om kanten"
+
+#~ msgid "right_face: ID of the face on the right of the edge"
+#~ msgstr "right_face: ID för ytan till höger om kanten"
+
+#~ msgid "Abs Next Edge & Next Edge"
+#~ msgstr "Abs Next Edge & Next Edge"
+
+#~ msgid ""
+#~ "The table edge_data has the columns abs_next_left_edge and "
+#~ "abs_next_right_edge, at this moment it gets a little tricky how to interpret"
+#~ " it."
+#~ msgstr ""
+#~ "Tabellen edge_data har kolumnerna abs_next_left_edge och "
+#~ "abs_next_right_edge, och nu blir det lite knepigt att tolka dem."
+
+#~ msgid ""
+#~ "Until now we mainly see properties of the edge itself and what has on the "
+#~ "sides, the next edge properties are different, do not ask only about the "
+#~ "edge itself, it is about which is the next edge who builds the face on the "
+#~ "right or left."
+#~ msgstr ""
+#~ "Hittills har vi främst sett egenskaper hos själva kanten och vad som har på "
+#~ "sidorna, nästa kants egenskaper är annorlunda, fråga inte bara om själva "
+#~ "kanten, det handlar om vilken som är nästa kant som bygger ytan till höger "
+#~ "eller vänster."
+
+#~ msgid ""
+#~ "The logic of the right_edge and the left_edge are very similar, so we will "
+#~ "look first on the left one deeper and then show the right one."
+#~ msgstr ""
+#~ "Logiken för höger_kant och vänster_kant är mycket lika, så vi kommer först "
+#~ "att titta på den vänstra djupare och sedan visa den högra."
+
+#~ msgid "We will be using the next topology as example:"
+#~ msgstr "Vi kommer att använda nästa topologi som exempel:"
+
+#~ msgid "Left"
+#~ msgstr "Vänster"
+
+#~ msgid ""
+#~ "Let's pick as an example the Edge 5, this one has on the Left the Face 2, "
+#~ "looking forward which is the next edge who builds the Face 2?"
+#~ msgstr ""
+#~ "Låt oss ta Edge 5 som exempel, den här har till vänster Face 2, om vi tittar"
+#~ " framåt vilken är nästa edge vem bygger Face 2?"
+
+#~ msgid "This is the Edge 6."
+#~ msgstr "Det här är Edge 6."
+
+#~ msgid ""
+#~ "Something very important here is the perspective we follow the lines, "
+#~ "depending on the Edge direction, is like see the Face clockwise or "
+#~ "anticlockwise."
+#~ msgstr ""
+#~ "Något mycket viktigt här är perspektivet vi följer linjerna, beroende på "
+#~ "kantriktningen, är det som att se detta face medurs eller moturs."
+
+#~ msgid "With this information we have abs_next_left_edge which will be 6."
+#~ msgstr ""
+#~ "Med denna information har vi abs_next_left_edge som kommer att vara 6."
+
+#~ msgid ""
+#~ "The next_left_edge is almost the same as abs_next_left_edge, except it can "
+#~ "be negative which depends on the perspective we see the edge."
+#~ msgstr ""
+#~ "next_left_edge är nästan samma sak som abs_next_left_edge, förutom att den "
+#~ "kan vara negativ, vilket beror på vilket perspektiv vi ser kanten från."
+
+#~ msgid ""
+#~ "If we follow the Edge perspective we will have two directions, the direction"
+#~ " of the next edge, and the direction of the perspective on the next edge."
+#~ msgstr ""
+#~ "Om vi följer Edge-perspektivet kommer vi att ha två riktningar, riktningen "
+#~ "mot nästa kant och riktningen för perspektivet på nästa kant."
+
+#~ msgid "We will use the next sign in each case:"
+#~ msgstr "Vi kommer att använda nästa tecken i varje fall:"
+
+#~ msgid "Perspective direction and Next edge direction are opposed: \"-\""
+#~ msgstr "Perspektivriktning och riktning mot nästa kant är motsatta: \"-\""
+
+#~ msgid ""
+#~ "Perspective direction and Next edge direction are the same: None, keep the "
+#~ "value positive"
+#~ msgstr ""
+#~ "Perspektivriktningen och Next edge-riktningen är desamma: None, behåll "
+#~ "värdet positivt"
+
+#~ msgid ""
+#~ "How the Perspective and Edge 6 have the same direction, next_left_edge will "
+#~ "be 6."
+#~ msgstr ""
+#~ "Eftersom perspektivet och Edge 6 har samma riktning kommer next_left_edge "
+#~ "att vara 6."
+
+#~ msgid "abs_next_left_edge: 6"
+#~ msgstr "abs_next_left_edge: 6"
+
+#~ msgid "next_left_edge: 6"
+#~ msgstr "next_left_edge: 6"
+
+#~ msgid "Right"
+#~ msgstr "Höger"
+
+#~ msgid ""
+#~ "The only difference between Left and Right analysis is the perspective, "
+#~ "while in Left we use forward, in Right we will see backwards. Be careful, "
+#~ "even if we look backwards the definition of Left Face and Right Face are "
+#~ "still the same, looking forward! Only changes the perspective to follow."
+#~ msgstr ""
+#~ "Den enda skillnaden mellan vänster och höger analys är perspektivet, medan "
+#~ "vi i vänster använder framåt, kommer vi i höger att se bakåt. Var försiktig,"
+#~ " även om vi tittar bakåt är definitionen av Left Face och Right Face "
+#~ "fortfarande densamma, framåtblickande! Det är bara perspektivet som ändras."
+
+#~ msgid ""
+#~ "The Edge 5 has the Face 0 on its Right, the Universal Face, looking Edge 5 "
+#~ "backwards the next edge who builds Face 0 is the Edge 4."
+#~ msgstr ""
+#~ "Edge 5 har Face 0 på sin högra sida, Universal Face, om man tittar Edge 5 "
+#~ "bakåt är nästa kant som bygger Face 0 Edge 4."
+
+#~ msgid ""
+#~ "Following the perspective of Edge 5 on Edge 4 we can see it goes up, while "
+#~ "the Edge 4 goes down, the Perspective direction and the Edge 4 direction are"
+#~ " opposed."
+#~ msgstr ""
+#~ "Om vi följer perspektivet för Edge 5 på Edge 4 kan vi se att den går upp, "
+#~ "medan Edge 4 går ner, perspektivets riktning och Edge 4:s riktning är "
+#~ "motsatta."
+
+#~ msgid "abs_next_right_edge: 4"
+#~ msgstr "abs_next_right_edge: 4"
+
+#~ msgid ""
+#~ "nexr_right_edge: -4 (Perspective direction and Edge 4 direction are opposed)"
+#~ msgstr ""
+#~ "nexr_right_edge: -4 (Perspektivriktning och Edge 4-riktning är motsatta)"
+
+#~ msgid "Isolated Edge Case"
+#~ msgstr "Isolerat kantfall"
+
+#~ msgid ""
+#~ "There is a case that may be confusing, all the rules above follow in the "
+#~ "same way but it is good to take a look."
+#~ msgstr ""
+#~ "Det finns ett fall som kan vara förvirrande, alla regler ovan följer på "
+#~ "samma sätt men det är bra att ta en titt."
+
+#~ msgid ""
+#~ "When we have an Edge that has no connections to other Edges, the first thing"
+#~ " we can appreciate is that the Face of the Left is the same as the Right, in"
+#~ " this case Face 0, the Universal Face."
+#~ msgstr ""
+#~ "När vi har en kant som inte har några kopplingar till andra kanter är det "
+#~ "första vi kan förstå att vänstersidan är densamma som högersidan, i det här "
+#~ "fallet Face 0, Universal Face."
+
+#~ msgid ""
+#~ "If we follow the past logic, on the Left is the Face 0, which is the next "
+#~ "edge who builds Face 0? Actually there is an Edge, and is itself, and it "
+#~ "also has a perspective as before:"
+#~ msgstr ""
+#~ "Om vi följer den tidigare logiken, till vänster är Face 0, vilket är nästa "
+#~ "kant som bygger Face 0? Det finns faktiskt en kant, och den är sig själv, "
+#~ "och den har också ett perspektiv som tidigare:"
+
+#~ msgid ""
+#~ "If we check the perspective direction we ends looking the same edge but in "
+#~ "opposite direction, this means the Edge 1 and its Next Edge (Edge 1) has "
+#~ "opposed directions."
+#~ msgstr ""
+#~ "Om vi kontrollerar perspektivriktningen slutar vi titta på samma kant men i "
+#~ "motsatt riktning, vilket innebär att Edge 1 och dess nästa kant (Edge 1) har"
+#~ " motsatta riktningar."
+
+#~ msgid "edge_id: 1"
+#~ msgstr "edge_id: 1"
+
+#~ msgid "abs_next_left_edge: 1"
+#~ msgstr "abs_next_left_edge: 1"
+
+#~ msgid ""
+#~ "next_left_edge: -1 (This will always be negative while we see forward a "
+#~ "isolated edge)"
+#~ msgstr ""
+#~ "next_left_edge: -1 (Detta kommer alltid att vara negativt när vi ser framåt "
+#~ "en isolerad kant)"
+
+#~ msgid ""
+#~ "For the Next Right Edge is the same, the Next Edge will be it self, the only"
+#~ " what it changes is the perspective:"
+#~ msgstr ""
+#~ "För nästa högra kant är densamma, nästa kant kommer att vara sig själv, det "
+#~ "enda som förändras är perspektivet:"
+
+#~ msgid ""
+#~ "When we look backwards any isolated edge, the perspective will always have "
+#~ "the same direction as the Edge so:"
+#~ msgstr ""
+#~ "När vi tittar bakåt på en isolerad kant kommer perspektivet alltid att ha "
+#~ "samma riktning som kanten:"
+
+#~ msgid "abs_next_right_edge: 1"
+#~ msgstr "abs_next_right_edge: 1"
+
+#~ msgid ""
+#~ "next_right_edge: -1 (This will always be positive while we see backwar a "
+#~ "isolated edge)"
+#~ msgstr ""
+#~ "next_right_edge: -1 (Detta kommer alltid att vara positivt medan vi ser "
+#~ "bakåt en isolerad kant)"
+
+#~ msgid "Full columns of edge_data"
+#~ msgstr "Fullständiga kolumner av edge_data"
+
+#~ msgid "We already checked all the columns of the edge_data table:"
+#~ msgstr "Vi har redan kontrollerat alla kolumner i tabellen edge_data:"
+
+#~ msgid "edge_id: Unique ID for the edge."
+#~ msgstr "edge_id: Unikt ID för kanten."
+
+#~ msgid ""
+#~ "start_node: ID for the node which is the same as the start point of the "
+#~ "edge."
+#~ msgstr ""
+#~ "start_node: ID för den nod som är densamma som startpunkten för kanten."
+
+#~ msgid ""
+#~ "end_node: ID for the node which is the same as the end point of the edge."
+#~ msgstr "end_node: ID för den nod som är densamma som slutpunkten för kanten."
+
+#~ msgid "left_face: ID of the face on the left of the edge."
+#~ msgstr "left_face: ID för den yta som ligger till vänster om kanten."
+
+#~ msgid "abs_next_left_edge: Next edge who builds the face on the left."
+#~ msgstr "abs_next_left_edge: Nästa kant som bygger ytan till vänster."
+
+#~ msgid ""
+#~ "next_left_edge: abs_next_left_edge and negative sign if the right face is on"
+#~ " the right of the next left edge."
+#~ msgstr ""
+#~ "next_left_edge: abs_next_left_edge och negativt tecken om den högra sidan är"
+#~ " till höger om nästa vänstra kant."
+
+#~ msgid "right_face: ID of the face on the right of the edge."
+#~ msgstr "right_face: ID för ytan till höger om kanten."
+
+#~ msgid "abs_next_right_edge: Next edge who builds the face on the right."
+#~ msgstr "abs_next_right_edge: Nästa kant som bygger ytan till höger."
+
+#~ msgid ""
+#~ "next_right_edge: abs_next_right_edge and negative sign if the left face is "
+#~ "on the right of the next right edge."
+#~ msgstr ""
+#~ "next_right_edge: abs_next_right_edge och negativt tecken om den vänstra "
+#~ "sidan är till höger om nästa högra kant."
+
+#~ msgid "geom: Geometry of the edge."
+#~ msgstr "geom: Geometri för kanten."


### PR DESCRIPTION
## Summary

- refresh the Spanish, Japanese, and Swedish `topology_topo_types` catalogs from the existing correct POT file
- remove the active duplicate `topology_base_types` source references from those catalogs
- clear the unrelated fuzzy carry-over strings so the `topology_topo_types` catalogs do not expose `topology_base_types` translations as active topology-topo text

Fixes postgis/postgis-workshops#162.

## Validation

- `msgmerge --update --backup=none ... topology_topo_types.po postgis-intro/sources/locale/pot/topology_topo_types.pot`
- `msgfmt --check --check-header --output-file=/dev/null` for the affected catalogs
- checked catalog inventory after refresh:
  - `topology_topo_types`: 102 active entries, 0 active fuzzy entries for `es`, `ja`, and `sv`
  - `topology_base_types`: existing active translations remain available (`es` 89/89, `ja` 88/89, `sv` 89/89)
- `rg -n "^#: .*topology_base_types" postgis-intro/sources/locale/*/LC_MESSAGES/topology_topo_types.po` returns no matches
- `LANG=es make -C postgis-intro/sources/en html-translation`
- `LANG=ja make -C postgis-intro/sources/en html-translation`
- `LANG=sv make -C postgis-intro/sources/en html-translation`
- `git diff --check`
