### PR TITLE
Fix translated PDF builds for CJK languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ sudo apt install texlive-lang-japanese
 ## PDF builds
 ```
 make pdf #builds just english
-#if you get errors about cmap.sty missing try doing:
-sudo apt install texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
+#if you get errors about cmap.sty or tgtermes.sty missing try doing:
+sudo apt install tex-gyre texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
 
 # to build Chinese, Japanese, and Korean translated PDFs, install latexmk,
-# xindy, FreeFont, and the CJK language collections used by the generated
-# Sphinx LaTeX sources:
-sudo apt install latexmk xindy fonts-freefont-otf texlive-lang-chinese texlive-lang-japanese texlive-lang-korean
+# xindy, XeLaTeX, FreeFont, Noto CJK, and the CJK language collections used by
+# the generated Sphinx LaTeX sources:
+sudo apt install latexmk xindy texlive-xetex fonts-freefont-otf fonts-noto-cjk texlive-lang-chinese texlive-lang-japanese texlive-lang-korean
 ```
 
 ### Slide Decks

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ sudo apt install texlive-lang-japanese
 make pdf #builds just english
 #if you get errors about cmap.sty missing try doing:
 sudo apt install texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra
+
+# to build Chinese, Japanese, and Korean translated PDFs, install latexmk,
+# xindy, FreeFont, and the CJK language collections used by the generated
+# Sphinx LaTeX sources:
+sudo apt install latexmk xindy fonts-freefont-otf texlive-lang-chinese texlive-lang-japanese texlive-lang-korean
 ```
 
 ### Slide Decks

--- a/postgis-intro/sources/en/conf.py
+++ b/postgis-intro/sources/en/conf.py
@@ -157,10 +157,21 @@ html_context = {'subheading': 'PostGIS extends PostgreSQL with robust spatial da
 # The font size ('10pt', '11pt' or '12pt').
 #latex_font_size = '11pt'
 
+if os.environ.get('LANG') == 'ko':
+  latex_engine = 'xelatex'
+
+
 latex_elements = {
   'papersize':'a4paper',
   'pointsize':'11pt'
 }
+
+if os.environ.get('LANG') == 'ko':
+  latex_elements['fontpkg'] = r'''
+\setmainfont{Noto Serif CJK KR}
+\setsansfont{Noto Sans CJK KR}
+\setmonofont{Noto Sans Mono CJK KR}[Scale=0.9]
+'''
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).

--- a/postgis-intro/sources/en/topology_topo_types.rst
+++ b/postgis-intro/sources/en/topology_topo_types.rst
@@ -30,19 +30,13 @@ Layers are the biggest box, they store TopoGeometries which also stores TopoElem
 
 Just to write in two ways:
 
-* Layer contains
+* A Layer contains TopoGeometries, and each TopoGeometry contains TopoElements
+  of the same TopoElement type.
+* Each TopoElement can represent a:
 
-  * TopoGeometries where all of them has the same TopoElement's type, each one one contains:
-
-    * TopoElements where each one can represent a:
-
-	        * TopoGeometry of other Layer
-        	* Geometry Collection
-	        * Primitive from the Topology
-
-                	* Nodes
-                	* Edges
-                	* Faces
+  * TopoGeometry of other Layer
+  * Geometry Collection
+  * Primitive from the Topology: Nodes, Edges, or Faces
 
 TopoGeometries are exposed as keys, they has a unique key inside the Layer, but also stores its Layer Key, this allows Postgis to store it in an arbitrary column and always be able to find its TopoElements, and with them what they represent.
 


### PR DESCRIPTION
## Summary

- document the Debian packages needed for Chinese, Japanese, and Korean translated PDF builds
- use XeLaTeX with Noto CJK fonts for Korean PDFs so Hangul glyphs render
- flatten an over-nested topology list that prevented LaTeX PDF output

Fixes postgis/postgis-workshops#121.

## Validation

- `make -C postgis-intro/sources/en pdf`
- `LANG=zh_Hans make -C postgis-intro/sources/en pdf-translation`
- `LANG=ja make -C postgis-intro/sources/en pdf-translation`
- `LANG=ko make -C postgis-intro/sources/en pdf-translation`
- clean Debian bookworm container using the documented apt packages built the
  English, Simplified Chinese, Japanese, and Korean PDFs
- Debbie (`debbie.postgis.net`) built the PR branch English, Simplified Chinese,
  Japanese, and Korean PDFs after installing the documented `xindy` and
  `fonts-noto-cjk` packages
- English, Simplified Chinese, Japanese, and Korean LaTeX output had no
  missing-character warnings
- `git diff --check`
